### PR TITLE
feat(foundations): repo skeleton, CLI parser, manifest module

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "allow": [
+      "mcp__linear__*",
+      "mcp__github__*",
+      "Bash(*)",
+      "Read(*)",
+      "Write(*)",
+      "Edit(*)",
+      "Glob(*)",
+      "Grep(*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+.pytest_cache/
+
+# Build / packaging
+dist/
+build/
+*.tar
+*.tar.zst
+*.tar.gz
+checksums.sha256
+
+# Bundles produced by capture
+general-backup-*.tar.zst
+secrets.age
+
+# Editor / OS
+.DS_Store
+*.swp
+.idea/
+.vscode/
+
+# Local state
+state/
+*.log
+.env
+.env.*
+!.env.example

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 zync-code
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: help test smoke install clean fmt lint
+
+PYTHON ?= python3
+BIN := bin/general-backup
+
+help:
+	@echo "Targets:"
+	@echo "  make test     Run unit tests"
+	@echo "  make smoke    Run capture smoke test (writes to /tmp)"
+	@echo "  make install  Symlink bin/general-backup into /usr/local/bin"
+	@echo "  make lint     Run pyflakes on lib/"
+	@echo "  make clean    Remove build artifacts"
+
+test:
+	$(PYTHON) -m unittest discover -s tests -t . -v
+
+smoke:
+	bash tests/smoke-capture.sh
+
+install:
+	install -m 0755 $(BIN) /usr/local/bin/general-backup
+
+lint:
+	$(PYTHON) -m pyflakes lib/ bin/general-backup || true
+
+clean:
+	rm -rf dist build __pycache__ */__pycache__ */*/__pycache__
+	rm -f general-backup-*.tar.zst checksums.sha256

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# general-backup
+
+Full-server snapshot and restore toolkit for Ubuntu 24.04.
+
+`general-backup` produces a single bundle that captures everything required to
+rebuild a Linux server: project trees, PostgreSQL/Redis data, nginx config,
+PM2 ecosystem, system users, SSH keys, cron, agent/skill state, package
+manifests. A restore on a fresh box brings it back online with one command.
+
+## Quickstart
+
+```bash
+# 1. On the source server: produce a bundle
+general-backup capture --age-recipient $(cat ~/.config/age/key.pub)
+
+# 2. Copy the bundle to the new server
+scp general-backup-*.tar.zst new-host:/tmp/
+
+# 3. On the new server: restore
+general-backup restore /tmp/general-backup-*.tar.zst --age-identity ~/.config/age/key.txt
+```
+
+Full docs live in [`docs/`](./docs) and the [PRD](./PRD.md).
+
+## CLI surface
+
+| Command  | Purpose                                                    |
+|----------|------------------------------------------------------------|
+| capture  | Produce a `<host>-<utcstamp>.tar.zst` bundle               |
+| restore  | Replay a bundle on a fresh Ubuntu 24.04 host               |
+| verify   | Check tarball integrity, manifest schema, age decryptable  |
+| diff     | Compare a bundle against the live host                     |
+| install  | Bootstrap a fresh box with the minimum toolchain           |
+
+Run `general-backup <subcommand> --help` for full options.
+
+## What's captured
+
+- `/home/bot/projects/` (excluding `node_modules`, `.next`, `dist`, `build`, etc.)
+- `~/.orchestrator`, `~/.claude` (filtered), `~/.config`
+- All `.env*` files (encrypted), `~/.ssh/*` (encrypted), gh tokens (encrypted)
+- PostgreSQL globals + per-DB `pg_dump --format=custom`
+- Redis `dump.rdb` + non-default `CONFIG`
+- PM2 `dump.pm2` + `jlist`
+- nginx `nginx.conf`, `sites-available/`, `conf.d/`, `sites-enabled` symlink map
+- Cron (`bot` crontab + `/etc/cron.d/*`)
+- System users delta (`/etc/passwd`, `/etc/group`, `/etc/sudoers.d/*`)
+- Package manifests (`apt-mark`, `dpkg --get-selections`, `pnpm/npm/pip`)
+
+See [PRD § 5](./PRD.md#5-scope--what-is-captured--out-of-scope) for the full list.
+
+## Security
+
+All sensitive data (env files, ssh keys, tokens, postgres role passwords,
+shadow lines, sudoers) is encrypted into `secrets.age` using
+[age](https://github.com/FiloSottile/age) with a recipient public key.
+The rest of the bundle is inspectable without the identity.
+
+## Repo layout
+
+```
+bin/general-backup     # CLI entrypoint
+lib/                   # Phase modules + manifest
+tests/                 # Smoke and round-trip tests
+docs/                  # Architecture, runbook, threat model
+PRD.md                 # Product requirements document
+```
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/bin/general-backup
+++ b/bin/general-backup
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""general-backup: full-server snapshot & restore toolkit.
+
+Entrypoint that wires the CLI to lib/cli.py.
+"""
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parent
+sys.path.insert(0, str(_ROOT))
+
+from lib.cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,3 @@
+"""general-backup library code."""
+
+__version__ = "1.0.0"

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -1,0 +1,159 @@
+"""CLI argument parser for general-backup.
+
+Subcommands: capture, restore, verify, diff, install.
+Each subcommand dispatches to a handler in the corresponding lib module.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import List, Sequence
+
+from . import __version__
+
+EXIT_OK = 0
+EXIT_USER_ERROR = 1
+EXIT_INTEGRITY = 2
+EXIT_PARTIAL = 3
+EXIT_PERMISSION = 4
+
+ALL_CAPTURE_PHASES = [
+    "inventory",
+    "packages",
+    "system",
+    "nginx",
+    "cron",
+    "postgres",
+    "redis",
+    "pm2",
+    "files",
+    "secrets",
+    "checksums",
+]
+
+ALL_RESTORE_PHASES = [
+    "bootstrap",
+    "packages",
+    "users",
+    "files",
+    "secrets",
+    "postgres",
+    "redis",
+    "nginx",
+    "pm2",
+    "cron",
+]
+
+
+def _csv(value: str) -> List[str]:
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="general-backup",
+        description="Full-server snapshot & restore toolkit (Ubuntu 24.04).",
+    )
+    p.add_argument("--version", action="version", version=f"general-backup {__version__}")
+
+    sub = p.add_subparsers(dest="command", required=True, metavar="COMMAND")
+
+    # capture
+    cap = sub.add_parser("capture", help="Produce a bundle from this host")
+    cap.add_argument("--out", help="Output bundle path (default: ./general-backup-<host>-<stamp>.tar.zst)")
+    cap.add_argument("--age-recipient", help="age recipient public key (X25519)")
+    cap.add_argument("--age-passphrase", action="store_true", help="Use a passphrase instead of a recipient key")
+    cap.add_argument(
+        "--include",
+        type=_csv,
+        default=["all"],
+        help=f"Comma list of phases to include (default: all). Choices: all,{','.join(ALL_CAPTURE_PHASES)}",
+    )
+    cap.add_argument("--exclude", type=_csv, default=[], help="Phases to subtract from --include")
+    cap.add_argument("--dry-run", action="store_true", help="Print plan, do nothing")
+    cap.add_argument("--sign", help="Path to a signing key for checksums.sha256")
+    cap.add_argument("--quiet", action="store_true")
+    cap.add_argument("--verbose", action="store_true")
+
+    # restore
+    rs = sub.add_parser("restore", help="Replay a bundle on a fresh host")
+    rs.add_argument("bundle", help="Path to bundle .tar.zst")
+    rs.add_argument("--target-user", default="bot")
+    rs.add_argument("--age-identity", help="Path to age identity (private key) file")
+    rs.add_argument(
+        "--phases",
+        type=_csv,
+        default=["all"],
+        help=f"Phases to run (default: all). Choices: all,{','.join(ALL_RESTORE_PHASES)}",
+    )
+    rs.add_argument("--skip-phases", type=_csv, default=[])
+    rs.add_argument("--dry-run", action="store_true", help="Show diff, no changes")
+    rs.add_argument("--force", action="store_true", help="Overwrite existing data")
+    rs.add_argument("--quiet", action="store_true")
+    rs.add_argument("--verbose", action="store_true")
+
+    # verify
+    vf = sub.add_parser("verify", help="Verify bundle integrity")
+    vf.add_argument("bundle", help="Path to bundle .tar.zst")
+    vf.add_argument("--age-identity", help="Optional: only required to test secrets decryptability")
+
+    # diff
+    df = sub.add_parser("diff", help="Diff a bundle against the live host")
+    df.add_argument("bundle", help="Path to bundle .tar.zst")
+    df.add_argument("--age-identity")
+
+    # install
+    ins = sub.add_parser("install", help="Bootstrap apt deps on a fresh Ubuntu 24.04 host")
+    ins.add_argument("--force-os", action="store_true", help="Skip the Ubuntu 24.04 check")
+
+    return p
+
+
+def _resolve_capture_phases(include: List[str], exclude: List[str]) -> List[str]:
+    if "all" in include:
+        phases = list(ALL_CAPTURE_PHASES)
+    else:
+        phases = [p for p in include if p in ALL_CAPTURE_PHASES]
+    return [p for p in phases if p not in exclude]
+
+
+def _resolve_restore_phases(phases: List[str], skip: List[str]) -> List[str]:
+    if "all" in phases:
+        ph = list(ALL_RESTORE_PHASES)
+    else:
+        ph = [p for p in phases if p in ALL_RESTORE_PHASES]
+    return [p for p in ph if p not in skip]
+
+
+def main(argv: Sequence[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "capture":
+        from .commands import capture as cmd
+        phases = _resolve_capture_phases(args.include, args.exclude)
+        return cmd.run(args, phases)
+
+    if args.command == "restore":
+        from .commands import restore as cmd
+        phases = _resolve_restore_phases(args.phases, args.skip_phases)
+        return cmd.run(args, phases)
+
+    if args.command == "verify":
+        from .commands import verify as cmd
+        return cmd.run(args)
+
+    if args.command == "diff":
+        from .commands import diff as cmd
+        return cmd.run(args)
+
+    if args.command == "install":
+        from .commands import install as cmd
+        return cmd.run(args)
+
+    parser.error(f"unknown command: {args.command}")
+    return EXIT_USER_ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/lib/commands/__init__.py
+++ b/lib/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Subcommand implementations."""

--- a/lib/commands/capture.py
+++ b/lib/commands/capture.py
@@ -1,0 +1,15 @@
+"""capture subcommand — stub. Phase modules wire in via subsequent PRs."""
+from __future__ import annotations
+
+from typing import List
+
+from ..log import info
+
+
+def run(args, phases: List[str]) -> int:
+    info(f"capture plan: phases={phases} out={args.out or '<auto>'} dry_run={args.dry_run}")
+    if args.dry_run:
+        info("dry-run mode — no actions taken")
+        return 0
+    info("capture pipeline not yet implemented (foundations PR only)")
+    return 0

--- a/lib/commands/diff.py
+++ b/lib/commands/diff.py
@@ -1,0 +1,10 @@
+"""diff subcommand — stub."""
+from __future__ import annotations
+
+from ..log import info
+
+
+def run(args) -> int:
+    info(f"diff bundle={args.bundle}")
+    info("diff not yet implemented (foundations PR only)")
+    return 0

--- a/lib/commands/install.py
+++ b/lib/commands/install.py
@@ -1,0 +1,10 @@
+"""install subcommand — stub. Real bootstrap.sh ships in Epic C."""
+from __future__ import annotations
+
+from ..log import info
+
+
+def run(args) -> int:
+    info("install: would invoke bootstrap.sh on this host")
+    info("install not yet implemented (foundations PR only)")
+    return 0

--- a/lib/commands/restore.py
+++ b/lib/commands/restore.py
@@ -1,0 +1,15 @@
+"""restore subcommand — stub. Phase modules wire in via subsequent PRs."""
+from __future__ import annotations
+
+from typing import List
+
+from ..log import info
+
+
+def run(args, phases: List[str]) -> int:
+    info(f"restore plan: bundle={args.bundle} phases={phases} dry_run={args.dry_run}")
+    if args.dry_run:
+        info("dry-run mode — no actions taken")
+        return 0
+    info("restore pipeline not yet implemented (foundations PR only)")
+    return 0

--- a/lib/commands/verify.py
+++ b/lib/commands/verify.py
@@ -1,0 +1,10 @@
+"""verify subcommand — stub."""
+from __future__ import annotations
+
+from ..log import info
+
+
+def run(args) -> int:
+    info(f"verify bundle={args.bundle}")
+    info("verify not yet implemented (foundations PR only)")
+    return 0

--- a/lib/log.py
+++ b/lib/log.py
@@ -1,0 +1,37 @@
+"""Tiny logging helpers used by all phases.
+
+Output goes to stderr so stdout stays clean for machine-parsable output
+(e.g., the bundle path printed at the end of a successful capture).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+QUIET = os.environ.get("GB_QUIET", "0") == "1"
+VERBOSE = os.environ.get("GB_VERBOSE", "0") == "1"
+
+
+def _ts() -> str:
+    return time.strftime("%H:%M:%S", time.gmtime())
+
+
+def info(msg: str) -> None:
+    if QUIET:
+        return
+    print(f"[{_ts()}] {msg}", file=sys.stderr)
+
+
+def warn(msg: str) -> None:
+    print(f"[{_ts()}] WARN: {msg}", file=sys.stderr)
+
+
+def error(msg: str) -> None:
+    print(f"[{_ts()}] ERROR: {msg}", file=sys.stderr)
+
+
+def debug(msg: str) -> None:
+    if not VERBOSE:
+        return
+    print(f"[{_ts()}] DEBUG: {msg}", file=sys.stderr)

--- a/lib/manifest.py
+++ b/lib/manifest.py
@@ -1,0 +1,156 @@
+"""Manifest dataclass + JSON schema + sha256 helpers.
+
+The manifest is the canonical description of a bundle: source host, OS,
+captured component summaries, exclusions list, and a pointer to the
+checksums file. It is `manifest.json` at the root of the unpacked bundle.
+"""
+from __future__ import annotations
+
+import dataclasses as dc
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = 1
+TOOL_VERSION = "1.0.0"
+
+DEFAULT_EXCLUSIONS: List[str] = [
+    "node_modules",
+    ".next",
+    "dist",
+    "build",
+    ".cache",
+    ".turbo",
+    "coverage",
+    ".claude/cache",
+    ".claude/paste-cache",
+    ".claude/shell-snapshots",
+    ".claude/telemetry",
+    ".claude/file-history",
+    ".claude/history.jsonl",
+]
+
+
+@dc.dataclass
+class Source:
+    hostname: str
+    os: str
+    kernel: str
+    user: str
+    uid: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dc.asdict(self)
+
+
+@dc.dataclass
+class Manifest:
+    schema_version: int = SCHEMA_VERSION
+    tool_version: str = TOOL_VERSION
+    captured_at: str = ""
+    source: Optional[Source] = None
+    components: Dict[str, Any] = dc.field(default_factory=dict)
+    exclusions: List[str] = dc.field(default_factory=lambda: list(DEFAULT_EXCLUSIONS))
+    checksums_file: str = "checksums.sha256"
+    secrets_encrypted: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = dc.asdict(self)
+        if self.source is not None:
+            d["source"] = self.source.to_dict()
+        return d
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+    def write(self, path: os.PathLike) -> None:
+        Path(path).write_text(self.to_json() + "\n", encoding="utf-8")
+
+    @classmethod
+    def read(cls, path: os.PathLike) -> "Manifest":
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Manifest":
+        src = data.get("source")
+        return cls(
+            schema_version=data.get("schema_version", SCHEMA_VERSION),
+            tool_version=data.get("tool_version", TOOL_VERSION),
+            captured_at=data.get("captured_at", ""),
+            source=Source(**src) if src else None,
+            components=data.get("components", {}),
+            exclusions=data.get("exclusions", list(DEFAULT_EXCLUSIONS)),
+            checksums_file=data.get("checksums_file", "checksums.sha256"),
+            secrets_encrypted=data.get("secrets_encrypted", True),
+        )
+
+    def validate(self) -> List[str]:
+        """Return a list of human-readable errors. Empty list = valid."""
+        errs: List[str] = []
+        if not isinstance(self.schema_version, int) or self.schema_version < 1:
+            errs.append("schema_version must be a positive int")
+        if self.schema_version > SCHEMA_VERSION:
+            errs.append(
+                f"schema_version {self.schema_version} is newer than this tool understands "
+                f"({SCHEMA_VERSION})"
+            )
+        if not self.captured_at:
+            errs.append("captured_at must be set")
+        if self.source is None:
+            errs.append("source must be set")
+        else:
+            for f in ("hostname", "os", "kernel", "user"):
+                if not getattr(self.source, f, None):
+                    errs.append(f"source.{f} must be set")
+        return errs
+
+
+def utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def sha256_file(path: os.PathLike, chunk: int = 1 << 20) -> str:
+    """Stream-hash a file. Returns lowercase hex digest."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            buf = f.read(chunk)
+            if not buf:
+                break
+            h.update(buf)
+    return h.hexdigest()
+
+
+def sha256_tree(root: os.PathLike) -> Dict[str, str]:
+    """SHA-256 every regular file under `root` (recursive). Returns
+    {relative_path: hex_digest}, sorted by path for stable output."""
+    root = Path(root)
+    out: Dict[str, str] = {}
+    for p in sorted(root.rglob("*")):
+        if p.is_file():
+            rel = p.relative_to(root).as_posix()
+            out[rel] = sha256_file(p)
+    return out
+
+
+def write_checksums(tree: Dict[str, str], path: os.PathLike) -> None:
+    """Write a checksums.sha256 file in the standard `<digest>  <path>` format."""
+    lines = [f"{digest}  {rel}\n" for rel, digest in sorted(tree.items())]
+    Path(path).write_text("".join(lines), encoding="utf-8")
+
+
+def parse_checksums(path: os.PathLike) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        digest, _, rel = line.partition("  ")
+        if not digest or not rel:
+            continue
+        out[rel] = digest
+    return out

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,89 @@
+"""Unit tests for lib.manifest. Uses stdlib unittest (no pytest dep)."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lib.manifest import (  # noqa: E402
+    Manifest,
+    Source,
+    parse_checksums,
+    sha256_file,
+    sha256_tree,
+    utc_now_iso,
+    write_checksums,
+)
+
+
+class ManifestTests(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            m = Manifest(
+                captured_at=utc_now_iso(),
+                source=Source(hostname="h1", os="Ubuntu 24.04", kernel="6.8.0", user="bot", uid=1000),
+                components={"postgres": {"databases": ["a", "b"], "version": "16"}},
+            )
+            p = tmp / "manifest.json"
+            m.write(p)
+            m2 = Manifest.read(p)
+            self.assertIsNotNone(m2.source)
+            assert m2.source is not None
+            self.assertEqual(m2.source.hostname, "h1")
+            self.assertEqual(m2.components["postgres"]["databases"], ["a", "b"])
+            self.assertEqual(m2.validate(), [])
+
+    def test_validate_catches_missing_fields(self) -> None:
+        m = Manifest()
+        errs = m.validate()
+        self.assertTrue(any("captured_at" in e for e in errs))
+        self.assertTrue(any("source" in e for e in errs))
+
+    def test_rejects_future_schema(self) -> None:
+        m = Manifest(
+            schema_version=999,
+            captured_at=utc_now_iso(),
+            source=Source(hostname="h", os="x", kernel="y", user="z", uid=0),
+        )
+        errs = m.validate()
+        self.assertTrue(any("newer" in e for e in errs))
+
+    def test_json_is_stable(self) -> None:
+        m = Manifest(
+            captured_at="2026-05-03T00:00:00Z",
+            source=Source(hostname="h", os="o", kernel="k", user="u", uid=1),
+        )
+        parsed = json.loads(m.to_json())
+        self.assertEqual(parsed["schema_version"], 1)
+        self.assertTrue(parsed["secrets_encrypted"])
+
+
+class HashTests(unittest.TestCase):
+    def test_sha256_file(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "x.bin"
+            p.write_bytes(b"hello world")
+            self.assertEqual(sha256_file(p), hashlib.sha256(b"hello world").hexdigest())
+
+    def test_sha256_tree_and_checksums_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            (tmp / "a.txt").write_text("aaa")
+            (tmp / "sub").mkdir()
+            (tmp / "sub" / "b.txt").write_text("bbb")
+            tree = sha256_tree(tmp)
+            self.assertEqual(set(tree.keys()), {"a.txt", "sub/b.txt"})
+            cks = tmp / "checksums.sha256"
+            write_checksums(tree, cks)
+            parsed = parse_checksums(cks)
+            self.assertEqual(parsed, tree)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Lays down the project foundations covering PRD roadmap items 1-3.

- `bin/general-backup` Python entrypoint
- `lib/cli.py` argparse with `capture`, `restore`, `verify`, `diff`, `install` subcommands
- `lib/manifest.py` dataclass + JSON schema validation + SHA-256 helpers (`sha256_file`, `sha256_tree`, `write_checksums`, `parse_checksums`)
- `lib/log.py` stderr logging helpers
- `lib/commands/*.py` subcommand stubs for all five commands
- `Makefile`, `.gitignore`, MIT `LICENSE`, baseline `README.md`
- `tests/test_manifest.py` stdlib `unittest` coverage (no pytest dep)

Subsequent PRs implement the real phase logic.

## Test plan

- [x] `python3 -m unittest discover -s tests -t . -v` → 6 tests pass
- [x] `./bin/general-backup --version` prints `general-backup 1.0.0`
- [x] `./bin/general-backup capture --dry-run` prints the capture plan

Closes GH-1