### PR TITLE
feat(manifest): upgrade schema to v2 with projects[] and toolchain

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,3 +1,3 @@
 """general-backup library code."""
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"

--- a/lib/manifest.py
+++ b/lib/manifest.py
@@ -1,8 +1,13 @@
 """Manifest dataclass + JSON schema + sha256 helpers.
 
 The manifest is the canonical description of a bundle: source host, OS,
-captured component summaries, exclusions list, and a pointer to the
-checksums file. It is `manifest.json` at the root of the unpacked bundle.
+toolchain versions, captured component summaries, the per-project map
+(name, git URL, branch, sha, env paths, pm2 apps, db names), exclusions
+list, and a pointer to the checksums file. It is `manifest.json` at the
+root of the unpacked bundle.
+
+Schema v2 (PRD §6) is the canonical schema. v1 bundles are no longer
+accepted by this tool — they predate the git-based projects model.
 """
 from __future__ import annotations
 
@@ -14,8 +19,8 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-SCHEMA_VERSION = 1
-TOOL_VERSION = "1.0.0"
+SCHEMA_VERSION = 2
+TOOL_VERSION = "2.0.0"
 
 DEFAULT_EXCLUSIONS: List[str] = [
     "node_modules",
@@ -47,21 +52,88 @@ class Source:
 
 
 @dc.dataclass
+class Toolchain:
+    """Tool versions captured from the source host. Replayed by bootstrap.sh."""
+
+    node: str = ""
+    pnpm: str = ""
+    pm2: str = ""
+    python3: str = ""
+    postgres: str = ""
+    redis: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dc.asdict(self)
+
+
+@dc.dataclass
+class Project:
+    """One project tree restored from git, plus the state needed to wire it
+    back into pm2 / nginx / postgres on the target host.
+
+    `git_url`, `branch`, and `sha` are the *only* things needed to recover
+    source. Everything else here describes how the project plugs into
+    services that were captured in the bundle.
+    """
+
+    name: str
+    git_url: str
+    branch: str
+    sha: str
+    project_dir: str
+    deploy_type: str = ""  # nginx | static | pm2-only | …
+    env_paths: List[str] = dc.field(default_factory=list)
+    pm2_apps: List[str] = dc.field(default_factory=list)
+    db_names: List[str] = dc.field(default_factory=list)
+    post_install: List[str] = dc.field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dc.asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Project":
+        return cls(
+            name=data["name"],
+            git_url=data["git_url"],
+            branch=data.get("branch", "main"),
+            sha=data.get("sha", ""),
+            project_dir=data.get("project_dir", ""),
+            deploy_type=data.get("deploy_type", ""),
+            env_paths=list(data.get("env_paths", [])),
+            pm2_apps=list(data.get("pm2_apps", [])),
+            db_names=list(data.get("db_names", [])),
+            post_install=list(data.get("post_install", [])),
+        )
+
+
+@dc.dataclass
 class Manifest:
     schema_version: int = SCHEMA_VERSION
     tool_version: str = TOOL_VERSION
     captured_at: str = ""
     source: Optional[Source] = None
+    toolchain: Toolchain = dc.field(default_factory=Toolchain)
+    projects: List[Project] = dc.field(default_factory=list)
     components: Dict[str, Any] = dc.field(default_factory=dict)
     exclusions: List[str] = dc.field(default_factory=lambda: list(DEFAULT_EXCLUSIONS))
     checksums_file: str = "checksums.sha256"
     secrets_encrypted: bool = True
+    runbook_sha256: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
-        d = dc.asdict(self)
-        if self.source is not None:
-            d["source"] = self.source.to_dict()
-        return d
+        return {
+            "schema_version": self.schema_version,
+            "tool_version": self.tool_version,
+            "captured_at": self.captured_at,
+            "source": self.source.to_dict() if self.source else None,
+            "toolchain": self.toolchain.to_dict(),
+            "projects": [p.to_dict() for p in self.projects],
+            "components": self.components,
+            "exclusions": self.exclusions,
+            "checksums_file": self.checksums_file,
+            "secrets_encrypted": self.secrets_encrypted,
+            "runbook_sha256": self.runbook_sha256,
+        }
 
     def to_json(self, indent: int = 2) -> str:
         return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
@@ -77,15 +149,19 @@ class Manifest:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Manifest":
         src = data.get("source")
+        tc = data.get("toolchain") or {}
         return cls(
             schema_version=data.get("schema_version", SCHEMA_VERSION),
             tool_version=data.get("tool_version", TOOL_VERSION),
             captured_at=data.get("captured_at", ""),
             source=Source(**src) if src else None,
+            toolchain=Toolchain(**tc) if isinstance(tc, dict) else Toolchain(),
+            projects=[Project.from_dict(p) for p in data.get("projects", [])],
             components=data.get("components", {}),
             exclusions=data.get("exclusions", list(DEFAULT_EXCLUSIONS)),
             checksums_file=data.get("checksums_file", "checksums.sha256"),
             secrets_encrypted=data.get("secrets_encrypted", True),
+            runbook_sha256=data.get("runbook_sha256", ""),
         )
 
     def validate(self) -> List[str]:
@@ -98,6 +174,11 @@ class Manifest:
                 f"schema_version {self.schema_version} is newer than this tool understands "
                 f"({SCHEMA_VERSION})"
             )
+        if self.schema_version < SCHEMA_VERSION:
+            errs.append(
+                f"schema_version {self.schema_version} is older than this tool supports "
+                f"({SCHEMA_VERSION}); v1 bundles predate the git-based projects model"
+            )
         if not self.captured_at:
             errs.append("captured_at must be set")
         if self.source is None:
@@ -106,6 +187,17 @@ class Manifest:
             for f in ("hostname", "os", "kernel", "user"):
                 if not getattr(self.source, f, None):
                     errs.append(f"source.{f} must be set")
+        seen: set = set()
+        for i, p in enumerate(self.projects):
+            if not p.name:
+                errs.append(f"projects[{i}].name must be set")
+            if not p.git_url:
+                errs.append(f"projects[{i}].git_url must be set")
+            if not p.sha:
+                errs.append(f"projects[{i}].sha must be set")
+            if p.name in seen:
+                errs.append(f"projects[].name duplicated: {p.name!r}")
+            seen.add(p.name)
         return errs
 
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -11,8 +11,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from lib.manifest import (  # noqa: E402
+    SCHEMA_VERSION,
     Manifest,
+    Project,
     Source,
+    Toolchain,
     parse_checksums,
     sha256_file,
     sha256_tree,
@@ -21,22 +24,54 @@ from lib.manifest import (  # noqa: E402
 )
 
 
+def _good_manifest() -> Manifest:
+    return Manifest(
+        captured_at=utc_now_iso(),
+        source=Source(hostname="h1", os="Ubuntu 24.04", kernel="6.8.0", user="bot", uid=1000),
+        toolchain=Toolchain(
+            node="18.19.1",
+            pnpm="9.0.0",
+            pm2="6.0.14",
+            python3="3.12.3",
+            postgres="16",
+            redis="7.0.15",
+        ),
+        projects=[
+            Project(
+                name="Automotive",
+                git_url="https://github.com/zync-code/Automotive.git",
+                branch="main",
+                sha="abc123def4567890",
+                project_dir="/home/bot/projects/Automotive",
+                deploy_type="nginx",
+                env_paths=[".env", "apps/web/.env.local"],
+                pm2_apps=["automotive-web", "automotive-api"],
+                db_names=["automotive_dev"],
+                post_install=["pnpm install"],
+            ),
+        ],
+        components={"postgres": {"databases": ["a", "b"], "version": "16"}},
+        runbook_sha256="0" * 64,
+    )
+
+
 class ManifestTests(unittest.TestCase):
     def test_round_trip(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
-            m = Manifest(
-                captured_at=utc_now_iso(),
-                source=Source(hostname="h1", os="Ubuntu 24.04", kernel="6.8.0", user="bot", uid=1000),
-                components={"postgres": {"databases": ["a", "b"], "version": "16"}},
-            )
+            m = _good_manifest()
             p = tmp / "manifest.json"
             m.write(p)
             m2 = Manifest.read(p)
             self.assertIsNotNone(m2.source)
             assert m2.source is not None
             self.assertEqual(m2.source.hostname, "h1")
-            self.assertEqual(m2.components["postgres"]["databases"], ["a", "b"])
+            self.assertEqual(m2.toolchain.node, "18.19.1")
+            self.assertEqual(len(m2.projects), 1)
+            self.assertEqual(m2.projects[0].name, "Automotive")
+            self.assertEqual(m2.projects[0].pm2_apps, ["automotive-web", "automotive-api"])
+            self.assertEqual(m2.projects[0].db_names, ["automotive_dev"])
+            self.assertEqual(m2.runbook_sha256, "0" * 64)
             self.assertEqual(m2.validate(), [])
 
     def test_validate_catches_missing_fields(self) -> None:
@@ -46,13 +81,29 @@ class ManifestTests(unittest.TestCase):
         self.assertTrue(any("source" in e for e in errs))
 
     def test_rejects_future_schema(self) -> None:
-        m = Manifest(
-            schema_version=999,
-            captured_at=utc_now_iso(),
-            source=Source(hostname="h", os="x", kernel="y", user="z", uid=0),
-        )
+        m = _good_manifest()
+        m.schema_version = 999
         errs = m.validate()
         self.assertTrue(any("newer" in e for e in errs))
+
+    def test_rejects_v1_schema(self) -> None:
+        m = _good_manifest()
+        m.schema_version = 1
+        errs = m.validate()
+        self.assertTrue(any("older" in e for e in errs))
+
+    def test_validate_catches_bad_projects(self) -> None:
+        m = _good_manifest()
+        m.projects.append(
+            Project(name="", git_url="", branch="main", sha="", project_dir=""),
+        )
+        m.projects.append(
+            Project(name="Automotive", git_url="g", branch="m", sha="s", project_dir="d"),
+        )
+        errs = m.validate()
+        self.assertTrue(any("name" in e for e in errs))
+        self.assertTrue(any("git_url" in e for e in errs))
+        self.assertTrue(any("duplicated" in e for e in errs))
 
     def test_json_is_stable(self) -> None:
         m = Manifest(
@@ -60,8 +111,12 @@ class ManifestTests(unittest.TestCase):
             source=Source(hostname="h", os="o", kernel="k", user="u", uid=1),
         )
         parsed = json.loads(m.to_json())
-        self.assertEqual(parsed["schema_version"], 1)
+        self.assertEqual(parsed["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(parsed["schema_version"], 2)
         self.assertTrue(parsed["secrets_encrypted"])
+        self.assertIn("toolchain", parsed)
+        self.assertIn("projects", parsed)
+        self.assertIn("runbook_sha256", parsed)
 
 
 class HashTests(unittest.TestCase):


### PR DESCRIPTION
## Description

Bring `lib/manifest.py` up to PRD v2.

- `SCHEMA_VERSION` → 2, `TOOL_VERSION` → "2.0.0".
- New `Toolchain` dataclass: node, pnpm, pm2, python3, postgres, redis.
- New `Project` dataclass: name, git_url, branch, sha, project_dir, deploy_type, env_paths[], pm2_apps[], db_names[], post_install[].
- `Manifest` carries `toolchain`, `projects[]`, `runbook_sha256`.
- `validate()` rejects v1 bundles, enforces required project fields, detects duplicate project names.
- `tests/test_manifest.py` covers v2 round-trip and the new validation rules.

Closes GH-16.