### PR TITLE
docs: rewrite README for PRD v2 and add docs/ suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,278 @@
 # general-backup
 
-Full-server snapshot and restore toolkit for Ubuntu 24.04.
+Stateful-delta snapshot and agent-driven restore for Ubuntu 24.04 servers.
 
-`general-backup` produces a single bundle that captures everything required to
-rebuild a Linux server: project trees, PostgreSQL/Redis data, nginx config,
-PM2 ecosystem, system users, SSH keys, cron, agent/skill state, package
-manifests. A restore on a fresh box brings it back online with one command.
+`general-backup` rebuilds a server from two ingredients:
+1. **Git remotes** — every project tree lives on GitHub. Source code is never bundled.
+2. **One bundle file** — the stateful delta that cannot live in git: PostgreSQL dumps, Redis snapshot, encrypted secrets, nginx config, PM2 ecosystem, system users, package lists, orchestrator state.
 
-## Quickstart
+---
+
+## 60-second quickstart
 
 ```bash
-# 1. On the source server: produce a bundle
-general-backup capture --age-recipient $(cat ~/.config/age/key.pub)
-
-# 2. Copy the bundle to the new server
-scp general-backup-*.tar.zst new-host:/tmp/
-
-# 3. On the new server: restore
-general-backup restore /tmp/general-backup-*.tar.zst --age-identity ~/.config/age/key.txt
+# On a fresh Ubuntu 24.04 box:
+git clone https://github.com/zync-code/general-backup.git
+cd general-backup
+./bootstrap.sh                              # installs all toolchain dependencies
+general-backup restore-agent ~/snapshot.tar.zst --age-identity ~/.config/age/key.txt
 ```
 
-Full docs live in [`docs/`](./docs) and the [PRD](./PRD.md).
+That's it. A Claude agent reads the bundle's `manifest.json` and `docs/restore-runbook.md`, then orchestrates the full restore: clones each project from GitHub at the captured SHA, applies env files, restores databases, reloads nginx, and resurrects PM2 processes.
 
-## CLI surface
+For a non-agent (scripted) restore:
 
-| Command  | Purpose                                                    |
-|----------|------------------------------------------------------------|
-| capture  | Produce a `<host>-<utcstamp>.tar.zst` bundle               |
-| restore  | Replay a bundle on a fresh Ubuntu 24.04 host               |
-| verify   | Check tarball integrity, manifest schema, age decryptable  |
-| diff     | Compare a bundle against the live host                     |
-| install  | Bootstrap a fresh box with the minimum toolchain           |
+```bash
+general-backup restore ~/snapshot.tar.zst --age-identity ~/.config/age/key.txt
+```
 
-Run `general-backup <subcommand> --help` for full options.
+---
 
-## What's captured
+## Capture walkthrough
 
-- `/home/bot/projects/` (excluding `node_modules`, `.next`, `dist`, `build`, etc.)
-- `~/.orchestrator`, `~/.claude` (filtered), `~/.config`
-- All `.env*` files (encrypted), `~/.ssh/*` (encrypted), gh tokens (encrypted)
-- PostgreSQL globals + per-DB `pg_dump --format=custom`
-- Redis `dump.rdb` + non-default `CONFIG`
-- PM2 `dump.pm2` + `jlist`
-- nginx `nginx.conf`, `sites-available/`, `conf.d/`, `sites-enabled` symlink map
-- Cron (`bot` crontab + `/etc/cron.d/*`)
-- System users delta (`/etc/passwd`, `/etc/group`, `/etc/sudoers.d/*`)
-- Package manifests (`apt-mark`, `dpkg --get-selections`, `pnpm/npm/pip`)
+```bash
+# 1. Generate an age key (once, store the private key outside the bundle)
+age-keygen -o ~/.config/age/key.txt
+cat ~/.config/age/key.txt | grep "public key" | awk '{print $NF}' > ~/.config/age/key.pub
 
-See [PRD § 5](./PRD.md#5-scope--what-is-captured--out-of-scope) for the full list.
+# 2. Produce a bundle on the source server
+general-backup capture --age-recipient $(cat ~/.config/age/key.pub)
+# Output: general-backup-<host>-<timestamp>.tar.zst
+
+# 3. Transfer to the target server
+scp general-backup-*.tar.zst new-host:/tmp/
+
+# 4. Verify integrity (no age key needed for this step)
+general-backup verify /tmp/general-backup-*.tar.zst
+
+# 5. Restore
+general-backup restore-agent /tmp/general-backup-*.tar.zst --age-identity ~/.config/age/key.txt
+```
+
+What capture does, in order:
+1. **preflight** — checks required tools, disk space, loads `projects.json`.
+2. **git-sync** — pushes every registered project to its GitHub remote. Dirty working trees get an automatic snapshot commit (disable with `--no-snapshot-commit`).
+3. **inventory** — records host, OS, toolchain versions.
+4. **packages** — apt manual list, dpkg selections, pnpm/npm/pip globals.
+5. **system** — passwd/group delta; shadow + sudoers staged for encryption.
+6. **nginx** — `/etc/nginx/` config + sites-enabled symlink map.
+7. **cron** — bot crontab + `/etc/cron.d/`.
+8. **postgres** — globals SQL + per-DB custom dumps + role password hashes (encrypted).
+9. **redis** — `SAVE`, copy `dump.rdb`, record non-default CONFIG.
+10. **pm2** — `pm2 save`, copy `dump.pm2`, `pm2 jlist`.
+11. **state** — tar+zstd of `~/.orchestrator`, `~/.claude` (filtered), `~/.config`, dotfiles.
+12. **secrets** — all `.env*` files, `~/.ssh/*`, gh tokens, role passwords, shadow lines → `age -r <recipient>` → `secrets.age`.
+13. **checksums** — sha256 every bundle file.
+14. **package** — final `tar -I zstd` output, prints path + size + sha256.
+
+---
+
+## Restore walkthrough
+
+### Script mode (deterministic, no LLM)
+
+```bash
+general-backup restore snapshot.tar.zst --age-identity ~/.config/age/key.txt
+```
+
+Phases run in order: bootstrap → packages → users → state-extract → secrets-decrypt → projects-clone → postgres → redis → nginx → pm2 → cron → postcheck.
+
+Each phase writes a done-marker under `/var/lib/general-backup/state/<phase>.ok`. If restore is interrupted, re-running it resumes from the last incomplete phase.
+
+### Agent mode (recommended for first-time / unusual restores)
+
+```bash
+general-backup restore-agent snapshot.tar.zst --age-identity ~/.config/age/key.txt
+```
+
+This extracts the bundle, verifies integrity, then spawns a Claude Code agent in a tmux session. The agent reads `docs/restore-runbook.md` (which is also embedded in every bundle) and orchestrates the restore, handling per-project quirks and logging every decision to `/var/log/general-backup-restore.log`.
+
+---
+
+## What's IN vs OUT of the bundle
+
+```
+IN THE BUNDLE (stateful delta)          NOT IN THE BUNDLE (comes from git)
+─────────────────────────────           ────────────────────────────────────
+PostgreSQL globals.sql                  /home/bot/projects/* source trees
+Per-DB .dump files (pg_dump custom)     package.json, lockfiles, configs
+Redis dump.rdb + non-default CONFIG     ecosystem.config.js
+PM2 dump.pm2 + jlist.json              project CLAUDE.md / PRD.md
+secrets.age (env files, SSH keys,       .claude/settings.json (committed)
+  gh tokens, role passwords,
+  shadow, sudoers)
+nginx config + sites-enabled map
+cron (bot crontab + /etc/cron.d/)
+System users delta (passwd/group)
+~/.orchestrator (configs, lib, cmds)
+~/.claude (settings, plugins, cmds)
+~/.config (gh, pnpm, turborepo)
+Home dotfiles (.bashrc, .profile)
+Package lists (apt, pnpm, npm, pip)
+manifest.json + checksums.sha256
+restore-runbook.md (snapshot)
+```
+
+---
+
+## Bundle layout
+
+```
+general-backup-<host>-<UTCstamp>/
+├── manifest.json                  # version, projects map, components, checksums ref
+├── restore-runbook.md             # the runbook version this bundle was built against
+├── README.txt                     # human-readable bundle summary
+├── secrets.age                    # age-encrypted vault (all plaintext secrets)
+├── data/
+│   ├── postgres/
+│   │   ├── globals.sql            # roles + tablespaces (no plaintext passwords)
+│   │   └── <dbname>.dump          # pg_dump --format=custom per database
+│   ├── redis/
+│   │   ├── dump.rdb
+│   │   └── config.json            # non-default CONFIG values
+│   ├── pm2/
+│   │   ├── dump.pm2
+│   │   └── jlist.json
+│   ├── nginx/
+│   │   ├── nginx.conf
+│   │   ├── sites-available/
+│   │   ├── sites-enabled.txt      # symlink target list
+│   │   └── conf.d/
+│   ├── cron/
+│   │   ├── bot.crontab
+│   │   └── etc-cron.d/
+│   └── system/
+│       ├── passwd.delta
+│       └── group.delta
+├── state/
+│   ├── orchestrator.tar.zst
+│   ├── claude.tar.zst
+│   ├── config.tar.zst
+│   ├── home-dotfiles.tar.zst
+│   └── projects.json
+├── packages/
+│   ├── apt-manual.txt
+│   ├── apt-selections.txt
+│   ├── npm-global.json
+│   ├── pnpm-global.json
+│   └── pip3-freeze.txt
+└── checksums.sha256
+```
+
+---
 
 ## Security
 
-All sensitive data (env files, ssh keys, tokens, postgres role passwords,
-shadow lines, sudoers) is encrypted into `secrets.age` using
-[age](https://github.com/FiloSottile/age) with a recipient public key.
-The rest of the bundle is inspectable without the identity.
+All sensitive material passes through [age](https://github.com/FiloSottile/age) before touching the bundle:
+
+- `.env*` files from all project trees
+- `~/.ssh/*`
+- `~/.config/gh/*` (GitHub tokens)
+- PostgreSQL role password hashes (from `pg_authid`)
+- `/etc/shadow` lines for restored users
+- `/etc/sudoers.d/*`
+- `~/.orchestrator/config/settings.json`
+
+Everything outside `secrets.age` is inspectable in the clear — useful for auditing what's in a bundle without the private key.
+
+**Age key management**
+
+```bash
+age-keygen -o ~/.config/age/key.txt   # generates private + public key
+```
+
+Store `~/.config/age/key.txt` **outside the bundle**, in a password manager or offline key store. Without it, `secrets.age` is unrecoverable. The public key (`key.pub`) is safe to embed in scripts and CI.
+
+See [docs/threat-model.md](./docs/threat-model.md) for the full attacker model.
+
+---
+
+## CLI reference
+
+```bash
+general-backup capture [OPTIONS]
+  --out PATH                 bundle output directory (default: current dir)
+  --age-recipient RECIPIENT  X25519 public key for secrets encryption
+  --allow-snapshot-commit    auto-commit dirty projects (default: on)
+  --no-snapshot-commit       abort if any project has uncommitted changes
+  --include-logs             include ~/.orchestrator/logs/ (default: off)
+  --dry-run                  print plan without executing
+  --include LIST             comma-separated phase names
+  --exclude LIST             comma-separated phase names to skip
+
+general-backup restore BUNDLE [OPTIONS]
+  --age-identity FILE        age private key for secrets decryption
+  --phases LIST              run only these phases
+  --skip-phases LIST         skip these phases
+  --dry-run                  print plan without executing
+  --force                    overwrite existing project directories
+
+general-backup restore-agent BUNDLE [OPTIONS]
+  --age-identity FILE        age private key
+  --auto-confirm             skip final agent confirmation prompt
+
+general-backup verify BUNDLE [--age-identity FILE]
+general-backup diff BUNDLE
+general-backup install-cron [--retain N] [--out-dir PATH]
+general-backup phase NAME [--bundle PATH]
+```
+
+Exit codes: `0` ok · `1` user error · `2` integrity error · `3` partial restore (resumable) · `4` permission error · `5` git-sync conflict.
+
+---
+
+## Failure-mode FAQ
+
+**Q: Capture failed mid-run. Do I lose everything?**
+No. Each phase is independently re-runnable. Re-run the same command; phases that completed are skipped.
+
+**Q: A project has uncommitted changes. Will capture skip it?**
+By default, capture creates a snapshot commit (`snapshot: pre-backup capture <timestamp>`) and pushes it. Disable this with `--no-snapshot-commit` (capture exits with code 5 listing dirty repos).
+
+**Q: Restore failed on the projects-clone phase. How do I resume?**
+Fix the problem (check network, GitHub credentials) then re-run `general-backup restore`. The done-marker at `/var/lib/general-backup/state/projects-clone.ok` will be absent, so it resumes from there.
+
+**Q: One project failed `pnpm install`. Does restore abort?**
+No. Failed installs mark the project as `degraded` and continue. The final `restore-report.md` lists all degraded projects with the error.
+
+**Q: I lost the age private key. Can I recover secrets?**
+No. `secrets.age` uses recipient-key encryption; without the private key it is unrecoverable. Store the key outside the bundle.
+
+**Q: The bundle manifest says schema_version 3 but my tool is version 2. What happens?**
+Restore refuses with exit code 2. Update `general-backup` first: `cd /home/bot/projects/general-backup && git pull`.
+
+**Q: How do I add a daily automatic capture?**
+```bash
+general-backup install-cron --retain 7 --out-dir /var/backups/general-backup
+```
+
+---
 
 ## Repo layout
 
 ```
-bin/general-backup     # CLI entrypoint
-lib/                   # Phase modules + manifest
-tests/                 # Smoke and round-trip tests
-docs/                  # Architecture, runbook, threat model
-PRD.md                 # Product requirements document
+bin/general-backup      CLI entrypoint
+lib/
+  cli.py                argument parser
+  manifest.py           schema v2 dataclass + validator
+  log.py                structured logging
+  commands/             subcommand implementations
+  phases/               capture + restore phase modules
+docs/
+  architecture.md       design rationale
+  restore-runbook.md    canonical agent restore prompt
+  threat-model.md       attacker model
+  extending.md          adding new components
+  operator-faq.md       operational troubleshooting
+tests/
+  smoke-capture.sh
+  git-sync.sh
+  restore-in-docker.sh
+bootstrap.sh            fresh Ubuntu 24.04 toolchain installer
+PRD.md                  product requirements
 ```
+
+---
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,89 @@
+# Architecture
+
+## Why git instead of bundling project source?
+
+The server hosts ~20 projects, totalling 11 GB on disk. If bundled, the snapshot would be slow to produce and slow to transfer. More importantly, the source is already in GitHub: every project has a registered `github_repo` in `~/.orchestrator/config/projects.json`. The bundle captures only the *difference* between what's in git and what a running server needs — roughly 90% of the size savings come from this one decision.
+
+The git pre-sync phase (`git-sync`) is the enforcement mechanism. Before any data capture, every project is pushed to its remote. The manifest records the exact SHA that was pushed. On restore, `git clone <url> && git checkout <sha>` reproduces the exact tree without any data living in the bundle.
+
+## Why a stateful-delta bundle?
+
+Some state genuinely cannot live in git:
+
+- **PostgreSQL data** — 10 databases with user content; `pg_dump` output is not committed to any repo.
+- **Redis state** — runtime cache and job queues.
+- **Secrets** — `.env` files, SSH keys, GitHub tokens, Postgres role passwords. These must never appear in git history, even in private repos.
+- **nginx config** — lives under `/etc/nginx/`, not in any project repo.
+- **System users** — `bot`'s uid, shadow lines, sudoers entries.
+- **Orchestrator + agent config** — `~/.orchestrator/` and `~/.claude/` contain command definitions, plugin configs, and project registries that are not project-specific.
+
+The bundle is a `tar.zst` archive. `zstd` at level 19 gives good compression with acceptable speed. The choice over `gzip` or `bz2` is wall-clock time at the compression level that matters: database dumps compress well and `zstd -19` is fast enough for the < 5 min target.
+
+## Why age for encryption?
+
+[age](https://github.com/FiloSottile/age) (Actually Good Encryption) is:
+
+- Simple: one recipient public key → one encrypted blob. No keyring management.
+- Auditable: small codebase, no footguns around modes or padding.
+- Apt-installable: `apt-get install age` on Ubuntu 24.04.
+- Supports recipient (X25519) and passphrase modes; we use recipient.
+
+The alternative (GPG) adds complexity with trust models, keyservers, and expiration. `age` does exactly what's needed: encrypt-to-public-key, decrypt-with-private-key.
+
+## Why an agent for restore?
+
+A monolithic shell script restoring 20 projects, 10 databases, and 5 nginx vhosts is brittle. Each project may need different steps: some need `pnpm install && pnpm build`, others just need env files and a PM2 entry. Some databases might already exist on the target. Some PM2 processes might conflict with existing entries.
+
+An agent (Claude Code via the orchestrator already used by `bot`) can:
+
+- Read the manifest and adapt per project.
+- Retry a failed `pnpm install` with a different strategy.
+- Ask the operator what to do when a database already exists with different schema.
+- Produce a readable restore-report.md with a summary of what worked and what didn't.
+
+Script mode (`general-backup restore`) remains the deterministic baseline. Agent mode is a layer on top that adds judgment for first-time or unusual restores.
+
+## Phase design
+
+Both capture and restore are decomposed into phases. Each phase:
+
+- Receives a `Context` object with a staging directory, manifest reference, and parsed args.
+- Writes its output to `ctx.staging/` (or `ctx.secrets_staging/` for sensitive files).
+- Raises `PhaseError` on failure; the orchestrator in `commands/capture.py` / `commands/restore.py` decides whether to abort or continue.
+- Is independently re-runnable (idempotent).
+
+Restore phases additionally write done-markers under `/var/lib/general-backup/state/<phase>.ok`. The orchestrator skips a phase if its marker exists. This enables resumability after a partial restore.
+
+## Manifest as the contract
+
+`manifest.json` is the single source of truth between capture and restore. Its schema (version 2) is defined in `lib/manifest.py`:
+
+- `projects[]` — what to clone, where, at what SHA, which env files, which PM2 apps, which databases.
+- `components` — summary counts (db count, pm2 process count, vhost count) used for post-restore verification.
+- `toolchain` — pinned versions that `bootstrap.sh` must install.
+- `schema_version` — restore refuses if the bundle's version exceeds the running tool's.
+- `checksums_file` — path to `checksums.sha256` which covers every file in the bundle except the checksum file itself.
+
+The `restore-runbook.md` embedded in the bundle is the version that was current at capture time. This ensures the agent running restore reads instructions consistent with the bundle's manifest, even if the repo has evolved.
+
+## Trust boundaries
+
+```
+┌─────────────────────────────────────────────┐
+│ secrets.age (encrypted at-rest)             │
+│   .env files, SSH keys, gh tokens,          │
+│   pg role passwords, shadow, sudoers         │
+└─────────────────────────────────────────────┘
+          ↑ age public key (safe to expose)
+          ↓ age private key (never in bundle)
+
+┌─────────────────────────────────────────────┐
+│ rest of bundle (cleartext, inspectable)     │
+│   manifest.json, checksums.sha256           │
+│   postgres dumps, redis rdb                 │
+│   nginx config, cron, system users delta    │
+│   state tarballs, package lists             │
+└─────────────────────────────────────────────┘
+```
+
+Anything in the cleartext portion is still private but not secret: it reveals database names, project names, nginx vhost names, and crontab schedules — operational metadata that doesn't grant access to running services.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,152 @@
+# Extending general-backup
+
+## Adding a new capture component (e.g. MongoDB)
+
+This example walks through adding MongoDB support. The same pattern applies to any new service.
+
+### 1. Write the capture phase module
+
+Create `lib/phases/mongodb.py`:
+
+```python
+"""MongoDB capture phase — dump all databases into staging."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from . import Context, PhaseError
+
+
+def run(ctx: Context) -> None:
+    out_dir = ctx.ensure_dir("data", "mongodb")
+
+    result = subprocess.run(
+        ["mongodump", "--out", str(out_dir), "--gzip"],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise PhaseError(f"mongodump failed: {result.stderr}")
+
+    # Record in manifest
+    db_names = [p.name for p in out_dir.iterdir() if p.is_dir()]
+    ctx.manifest.components["mongodb"] = {"databases": db_names}
+```
+
+### 2. Write the restore phase module
+
+Create `lib/phases/restore_mongodb.py`:
+
+```python
+"""MongoDB restore phase — restore all databases from staging."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from . import Context, PhaseError
+
+
+def run(ctx: Context) -> None:
+    dump_dir = ctx.staging / "data" / "mongodb"
+    if not dump_dir.exists():
+        return  # nothing to restore
+
+    result = subprocess.run(
+        ["mongorestore", "--gzip", str(dump_dir)],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise PhaseError(f"mongorestore failed: {result.stderr}")
+```
+
+### 3. Add the preflight tool check
+
+In `lib/phases/preflight.py`, add `"mongodump"` and `"mongorestore"` to the required tools list (or make them conditional on whether MongoDB is detected).
+
+### 4. Register the phase in the capture pipeline
+
+In `lib/commands/capture.py`, add `"mongodb"` to the default phase list in the correct position (after `redis`, before `pm2`). The phase name must match the module filename.
+
+### 5. Register the restore phase
+
+In `lib/commands/restore.py`, add `"mongodb"` to the restore phase list (after `redis`, before `nginx`).
+
+### 6. Update bootstrap.sh
+
+Add `mongodb-org` to the apt install block in `bootstrap.sh`. Pin the version to match what the manifest records.
+
+### 7. Update the manifest schema
+
+In `lib/manifest.py`, add `mongodb` to the `components` TypedDict if you want strict schema validation.
+
+### 8. Add a test
+
+In `tests/smoke-capture.sh`, verify that `data/mongodb/` appears in the bundle and that `general-backup verify` still passes.
+
+---
+
+## Adding a new project type
+
+Projects are registered in `~/.orchestrator/config/projects.json`. The `deploy_type` field controls how the restore agent handles post-clone setup.
+
+### Current deploy types
+
+| `deploy_type` | What restore does |
+|---------------|-------------------|
+| `nginx` | `pnpm install`, `pnpm build`, links nginx vhost |
+| (unset) | `pnpm install` only, no nginx |
+
+### Adding a new deploy type (e.g. `docker-compose`)
+
+1. In `lib/phases/git_sync.py`, the `deploy_type` from `projects.json` is passed through to `manifest.projects[]` as-is. No code change needed here.
+
+2. In `docs/restore-runbook.md`, add a section describing what the agent should do for `deploy_type: docker-compose`:
+   ```
+   If deploy_type == "docker-compose":
+     Run: docker compose up -d
+     Verify: docker compose ps shows all services Up
+   ```
+
+3. In `lib/phases/restore_projects.py` (script-mode restore), add a branch:
+   ```python
+   if project["deploy_type"] == "docker-compose":
+       subprocess.run(["docker", "compose", "up", "-d"], cwd=project_dir, check=True)
+   ```
+
+4. Update `bootstrap.sh` to install Docker if any registered project uses `deploy_type: docker-compose`.
+
+---
+
+## Adding a new per-project metadata field
+
+Say you want to capture a `post_install` list of commands per project.
+
+1. In `lib/phases/git_sync.py`, read the field from `projects.json`:
+   ```python
+   entry["post_install"] = proj.get("post_install", [])
+   ```
+
+2. In `lib/manifest.py`, add `post_install: List[str]` to the project entry TypedDict.
+
+3. In `lib/phases/restore_projects.py`, execute the commands after `pnpm install`:
+   ```python
+   for cmd in project.get("post_install", []):
+       subprocess.run(cmd, shell=True, cwd=project_dir, check=True)
+   ```
+
+4. In `docs/restore-runbook.md`, document that the agent should run `post_install` commands after the standard install steps.
+
+---
+
+## Changing the secrets vault contents
+
+All files to be encrypted land in `ctx.secrets_staging/` during their respective phases. The `secrets` phase then tars and pipes this directory through `age`.
+
+To add a new secret type (e.g. a per-project API key file at a custom path):
+
+1. In the relevant capture phase (e.g. `lib/phases/state.py`), copy the file to `ctx.secrets_dir("my-service/api-key.txt")`.
+
+2. In the restore phase, after `secrets-decrypt` has placed files in the tmpfs staging dir, read the file from the staging path and install it at the correct location on disk.
+
+3. Record the target path in `manifest.projects[].env_paths` (or a new manifest field) so the agent knows where it was placed and can verify it's present after restore.

--- a/docs/operator-faq.md
+++ b/docs/operator-faq.md
@@ -1,0 +1,253 @@
+# Operator FAQ
+
+## Capture issues
+
+### Capture aborts with "dirty repo" and exit code 5
+
+A registered project has uncommitted changes and `--no-snapshot-commit` was passed (or the default `--allow-snapshot-commit` was explicitly overridden).
+
+**Fix**: either commit and push the changes manually, or run capture without `--no-snapshot-commit` to let it create a snapshot commit automatically.
+
+```bash
+# See which projects are dirty
+general-backup capture --dry-run 2>&1 | grep dirty
+
+# Allow automatic snapshot commits (default behaviour)
+general-backup capture --age-recipient $(cat ~/.config/age/key.pub)
+```
+
+---
+
+### Capture fails on the postgres phase with "permission denied"
+
+The postgres phase reads `pg_authid` to extract role password hashes. This requires SUPERUSER.
+
+**Fix**: run capture as a user with SUPERUSER, or use `psql -U postgres`:
+
+```bash
+sudo -u postgres general-backup capture --age-recipient ...
+```
+
+If SUPERUSER access is not available, role passwords will be missing from the bundle. Restore will succeed but databases will reject application connections until passwords are set manually.
+
+---
+
+### Capture is running but no output appears for 2+ minutes
+
+The `git-sync` phase is pushing large repositories over the network. This is expected. The phase logs each project name as it starts.
+
+To see verbose output: add `--verbose` to the capture command.
+
+---
+
+### Bundle is larger than expected
+
+Check whether `--include-logs` was passed. The `~/.orchestrator/logs/` directory can be several hundred MB. Omit it unless you specifically need log history in the bundle.
+
+```bash
+# Check bundle contents without extracting
+tar -tvf general-backup-*.tar.zst | sort -k5 -rn | head -20
+```
+
+---
+
+### age is not installed
+
+```bash
+sudo apt-get install age
+```
+
+age is in the Ubuntu 24.04 main repository.
+
+---
+
+## Restore issues
+
+### Restore fails at secrets-decrypt: "no identity matched a recipient"
+
+The age private key passed via `--age-identity` does not correspond to the public key used at capture time.
+
+**Check**: compare the public key fingerprint:
+
+```bash
+age-keygen -y ~/.config/age/key.txt       # prints the public key from a private key file
+cat ~/.config/age/key.pub                  # the public key used at capture
+```
+
+If they don't match, you are using the wrong private key. Retrieve the correct one from your password manager or offline backup.
+
+---
+
+### Restore fails at projects-clone: "repository not found"
+
+The GitHub repo at the captured URL is private and the `bot` user's GitHub token is not yet installed (secrets-decrypt must run first) — or the token has expired.
+
+**Fix**: ensure secrets-decrypt completed before projects-clone:
+
+```bash
+general-backup restore snapshot.tar.zst --age-identity key.txt --phases secrets-decrypt,projects-clone
+```
+
+If the token is expired, create a new GitHub PAT, update `~/.config/gh/hosts.yml` manually, then re-run from projects-clone.
+
+---
+
+### One project fails pnpm install during restore
+
+The restore continues and marks the project as `degraded`. After restore completes, check `restore-report.md` for the error.
+
+**Fix**:
+
+```bash
+cd /home/bot/projects/<project-name>
+pnpm install       # attempt manually; read the error output
+```
+
+Common causes: incompatible Node version, network timeout, private npm registry token in `.env` not yet applied (if secrets-decrypt didn't complete before projects-clone).
+
+---
+
+### pm2 resurrect shows 0 processes after restore
+
+The `dump.pm2` file may not have been written at capture time (pm2 was not running, or the pm2 phase was skipped).
+
+**Check**:
+
+```bash
+tar -tvf snapshot.tar.zst | grep dump.pm2
+```
+
+If `dump.pm2` is present but pm2 still shows 0 processes:
+
+```bash
+cat ~/.pm2/dump.pm2    # verify it contains process entries
+pm2 resurrect          # retry manually
+pm2 save               # save the in-memory list back to dump.pm2
+```
+
+---
+
+### nginx -t fails after restore
+
+Check the nginx error log:
+
+```bash
+nginx -t 2>&1
+sudo journalctl -u nginx --no-pager | tail -30
+```
+
+Common causes:
+- An env variable used in a `include` directive is not set (secrets-decrypt may not have run).
+- A site references a certificate path that does not exist on the target (certificates are not in the bundle; obtain them with certbot).
+
+For Let's Encrypt certificates:
+
+```bash
+sudo certbot --nginx -d yourdomain.com
+```
+
+---
+
+### Restore is interrupted. How do I resume?
+
+Just re-run the same `restore` command. Done-markers under `/var/lib/general-backup/state/` tell the orchestrator which phases completed. Only the incomplete phases will re-run.
+
+```bash
+ls /var/lib/general-backup/state/          # see which phases are done
+general-backup restore snapshot.tar.zst --age-identity key.txt
+```
+
+To force a phase to re-run, delete its marker:
+
+```bash
+rm /var/lib/general-backup/state/postgres.ok
+general-backup restore snapshot.tar.zst --age-identity key.txt
+```
+
+---
+
+### verify reports checksum mismatch
+
+The bundle file was corrupted in transit.
+
+**Fix**: re-transfer the bundle, then verify again:
+
+```bash
+general-backup verify snapshot.tar.zst
+```
+
+If the source bundle itself is corrupt (e.g. disk error on the source server), you will need a previous capture. This is why `install-cron` retains 7 bundles by default.
+
+---
+
+## Operational tasks
+
+### Set up daily automatic capture
+
+```bash
+general-backup install-cron --retain 7 --out-dir /var/backups/general-backup --age-recipient $(cat ~/.config/age/key.pub)
+```
+
+This writes `/etc/cron.d/general-backup` running capture daily and pruning bundles older than N=7.
+
+---
+
+### Verify a bundle without restoring
+
+```bash
+general-backup verify snapshot.tar.zst
+# With age check (verifies decryptable but does not extract secrets):
+general-backup verify snapshot.tar.zst --age-identity ~/.config/age/key.txt
+```
+
+---
+
+### Check what a restore would change on the current host
+
+```bash
+general-backup diff snapshot.tar.zst
+```
+
+Output is grouped by component (projects, postgres, redis, pm2, nginx, packages) and shows:
+- Projects in manifest but missing on host
+- Projects on host but not in manifest
+- Databases missing from host
+- pm2 process count delta
+- Package list diff
+
+---
+
+### Rotate the age key
+
+Rotating the encryption key requires re-capturing with the new key. There is no re-encryption path for existing bundles (age bundles are not re-keyable without decrypting and re-encrypting).
+
+1. Generate a new key: `age-keygen -o ~/.config/age/key-new.txt`
+2. Run a fresh capture: `general-backup capture --age-recipient $(age-keygen -y ~/.config/age/key-new.txt)`
+3. Store `key-new.txt` in your password manager.
+4. Retire the old key after confirming the new bundle restores correctly.
+
+---
+
+### Capture only specific components
+
+```bash
+# Capture only databases and redis (skip everything else)
+general-backup capture --include postgres,redis --age-recipient $(cat ~/.config/age/key.pub)
+
+# Capture everything except the state tarballs
+general-backup capture --exclude state --age-recipient $(cat ~/.config/age/key.pub)
+```
+
+---
+
+### Run a single phase manually
+
+```bash
+# Capture phase (writes to a staging dir)
+general-backup phase capture-postgres
+
+# Restore phase (reads from a bundle)
+general-backup phase restore-projects --bundle /tmp/snapshot.tar.zst
+```
+
+Useful for debugging a specific phase without running the full pipeline.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,114 @@
+# Threat Model
+
+## What an attacker gets with the bundle but no age key
+
+The bundle (`general-backup-<host>-<timestamp>.tar.zst`) splits into two parts: a cleartext section and `secrets.age`.
+
+With only the bundle (no age private key), an attacker can read:
+
+| What they can read | What they learn |
+|--------------------|-----------------|
+| `manifest.json` | Hostname, OS, project names, GitHub URLs, database names, PM2 process names, nginx vhost names |
+| `data/postgres/globals.sql` | Role names, tablespace names — **no passwords** |
+| `data/postgres/<db>.dump` | Full database contents (user data, application data) |
+| `data/redis/dump.rdb` | Full Redis keyspace (session data, cache, job queues) |
+| `data/nginx/` | Full nginx config including upstream addresses, locations, SSL certificate paths |
+| `data/pm2/jlist.json` | Process names, cwd, env var **names** (but not values — those are in secrets.age) |
+| `data/system/passwd.delta` | Non-system usernames and uids |
+| `state/*.tar.zst` | Orchestrator command definitions, Claude plugin configs, non-secret app configs |
+| `packages/` | Installed package list |
+
+What they **cannot** read without the age key:
+
+- `.env*` file contents (API keys, database passwords, third-party tokens)
+- `~/.ssh/*` private keys
+- GitHub tokens (`~/.config/gh/hosts.yml`)
+- PostgreSQL role password hashes
+- `/etc/shadow` entries
+- `/etc/sudoers.d/` entries
+- `~/.orchestrator/config/settings.json` (telegram bot token, etc.)
+
+### Impact without the age key
+
+An attacker with the bundle but no key can:
+- Read all application data from the postgres dumps and redis snapshot.
+- Map the full server topology (projects, services, vhosts, processes).
+- Attempt to restore a clone without `secrets-decrypt` (no env files or SSH keys; postgres will have wrong role passwords; nginx will start but apps won't connect to APIs).
+
+They **cannot** authenticate to GitHub, connect to external APIs, SSH into other servers, or gain `sudo` access to the target.
+
+---
+
+## What an attacker gets with the age key alone
+
+With only `~/.config/age/key.txt` (the age private key) and **no bundle**, an attacker can decrypt any bundle that was encrypted to the corresponding public key. The key itself reveals nothing on its own.
+
+---
+
+## What an attacker gets with both bundle and age key
+
+Full server reconstruction capability. This is equivalent to root access to the original server from a data-access perspective.
+
+This is why the private key must be stored outside the bundle: in a password manager, offline hardware key, or separate secure storage that is not transmitted alongside the bundle.
+
+---
+
+## Threat scenarios
+
+### Bundle intercepted in transit
+
+**Risk**: an attacker intercepts the `scp` or file transfer of the bundle.
+
+**Mitigation**: they get all application data (postgres, redis) and the full server topology but not credentials or keys. Transfer the bundle over SSH; the cleartext exposure is an operational risk, not a cryptographic one.
+
+**Recommendation**: use `general-backup verify` on the target after transfer to confirm integrity.
+
+---
+
+### Bundle stored on a shared or compromised server
+
+**Risk**: the bundle is stored in a location accessible to other users or a compromised process.
+
+**Mitigation**: restrict bundle file permissions (`chmod 600`). The age key should never be co-located with the bundle on the same storage medium.
+
+---
+
+### Age key stored in the same place as the bundle
+
+**Risk**: operator copies `key.txt` next to the bundle for convenience.
+
+**Mitigation**: the age key file is deliberately not included in any automated workflow. The operator must explicitly pass `--age-identity FILE` at restore time.
+
+**Recommendation**: store the age private key in a password manager and export it to a file only at restore time.
+
+---
+
+### Snapshot commit leaks secrets
+
+**Risk**: the `--allow-snapshot-commit` mode commits all tracked files and pushes. If any `.env*` file was accidentally `git add`-ed, it lands on GitHub.
+
+**Mitigation**: the `git-sync` phase does `git add -A` only on files already tracked (it does not add untracked files). `.env*` files are typically in `.gitignore`. The smoke-capture test (`tests/smoke-capture.sh`) greps the entire cleartext bundle for patterns like `ghp_|gho_|sk-|password|BEGIN [A-Z]+ PRIVATE KEY` and fails if any appear outside `secrets.age`.
+
+---
+
+### Restore on a non-isolated target exposes secrets
+
+**Risk**: `secrets-decrypt` extracts age contents to a tmpfs staging directory and writes env files to project directories. If the target has other users or processes, they could read these files during restore.
+
+**Mitigation**: restore should be run on a freshly provisioned host with only the `bot` user. The staging tmpfs is `chmod 700`. Env files are written with mode `600`.
+
+---
+
+### Postgres role passwords captured incorrectly
+
+**Risk**: `pg_authid` extract requires SUPERUSER. If the capture user does not have SUPERUSER, role passwords are not captured and restore will fail to authenticate apps to their databases.
+
+**Mitigation**: the preflight phase checks for SUPERUSER access and warns if unavailable. The capture can proceed without role passwords but the restore-report will flag affected roles.
+
+---
+
+## What age does NOT protect against
+
+- Metadata: bundle filenames, directory structure, file sizes, and modification times are visible in the tarball even without the age key.
+- Future key compromise: age does not provide forward secrecy. If the private key is compromised in the future, all past bundles encrypted to that public key become decryptable.
+- Integrity of the cleartext section: `checksums.sha256` covers all bundle files and is verified by `general-backup verify`, but an attacker with write access to the bundle could tamper with both the data and the checksum file. For high-assurance scenarios, sign the checksum file with `--sign KEYFILE` at capture time.


### PR DESCRIPTION
## Description

Rewrites README.md to reflect PRD v2 (git-based projects, agent-driven restore) and authors the full `docs/` suite.

**README.md** (complete rewrite per PRD §13):
- 60-second quickstart: clone → bootstrap → restore-agent
- Capture walkthrough with phase-by-phase breakdown
- Restore walkthrough (script mode + agent mode)
- What's IN vs OUT of the bundle (clear table)
- Bundle layout diagram
- Security notes: age encryption model, key management warning
- CLI reference with all flags
- Failure-mode FAQ (7 entries)
- Repo layout

**docs/architecture.md** — design rationale:
- Why git instead of bundling source (11 GB → lean bundle)
- Why zstd + age
- Why agent restore vs monolithic shell script
- Phase design (Context, PhaseError, done-markers)
- Manifest as the contract between capture and restore
- Trust boundary diagram

**docs/threat-model.md** — attacker model:
- What bundle-only access reveals (DB contents, topology, no credentials)
- What key-only access reveals (nothing without a bundle)
- What bundle + key grants (full reconstruction)
- 7 threat scenarios with mitigations
- What age does NOT protect against

**docs/extending.md** — how to add new components:
- Adding a new capture/restore service (MongoDB walkthrough)
- Adding a new project deploy_type (docker-compose walkthrough)
- Adding new per-project metadata fields
- Adding new secrets vault contents

**docs/operator-faq.md** — operational troubleshooting:
- Capture failure modes (dirty repo, permissions, bundle size)
- Restore failure modes (age key mismatch, pnpm install, pm2, nginx)
- Resumability (done-markers)
- Daily cron setup, verify, diff, key rotation, selective capture

Closes GH-29