### PR TITLE
test: add smoke-capture, git-sync, and restore-in-docker tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,29 @@
-.PHONY: help test smoke install clean fmt lint
+.PHONY: help test smoke git-sync docker-restore install clean fmt lint
 
 PYTHON ?= python3
 BIN := bin/general-backup
 
 help:
 	@echo "Targets:"
-	@echo "  make test     Run unit tests"
-	@echo "  make smoke    Run capture smoke test (writes to /tmp)"
-	@echo "  make install  Symlink bin/general-backup into /usr/local/bin"
-	@echo "  make lint     Run pyflakes on lib/"
-	@echo "  make clean    Remove build artifacts"
+	@echo "  make test           Run unit tests"
+	@echo "  make smoke          Run capture smoke test (writes to /tmp)"
+	@echo "  make git-sync       Test git-sync phase semantics"
+	@echo "  make docker-restore Round-trip restore test in Docker (requires docker)"
+	@echo "  make install        Symlink bin/general-backup into /usr/local/bin"
+	@echo "  make lint           Run pyflakes on lib/"
+	@echo "  make clean          Remove build artifacts"
 
 test:
 	$(PYTHON) -m unittest discover -s tests -t . -v
 
 smoke:
 	bash tests/smoke-capture.sh
+
+git-sync:
+	bash tests/git-sync.sh
+
+docker-restore:
+	bash tests/restore-in-docker.sh
 
 install:
 	install -m 0755 $(BIN) /usr/local/bin/general-backup

--- a/tests/git-sync.sh
+++ b/tests/git-sync.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Test the git-sync phase semantics:
+#
+#   1. A project with uncommitted changes + --no-snapshot-commit → exit 5
+#   2. A project with uncommitted changes + default (--allow-snapshot-commit) →
+#      exit 0, manifest.projects[] records the new SHA, origin has that SHA
+#
+# The test wires a synthetic projects.json that points at a temp project with
+# a local bare-repo origin so no real GitHub I/O is needed.
+#
+# Usage:
+#   bash tests/git-sync.sh
+#
+# Environment:
+#   GB_BIN  — path to general-backup binary (default: bin/general-backup)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GB_BIN="${GB_BIN:-${REPO_ROOT}/bin/general-backup}"
+TMPDIR_BASE="$(mktemp -d /tmp/gb-git-sync-XXXXXX)"
+
+pass()    { printf '\033[32mPASS\033[0m %s\n' "$1"; }
+fail()    { printf '\033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
+info()    { printf '     %s\n' "$1"; }
+
+cleanup() { rm -rf "${TMPDIR_BASE}"; }
+trap cleanup EXIT
+
+# ── Setup: bare-repo origin + working clone ───────────────────────────────────
+
+BARE_REPO="${TMPDIR_BASE}/origin.git"
+WORK_REPO="${TMPDIR_BASE}/work"
+STAGING_DIR="${TMPDIR_BASE}/staging"
+PROJECTS_JSON="${TMPDIR_BASE}/projects.json"
+
+# Create bare remote
+git init --bare "${BARE_REPO}" -q
+git -C "${BARE_REPO}" config receive.denyCurrentBranch ignore
+
+# Clone into working copy
+git clone "${BARE_REPO}" "${WORK_REPO}" -q 2>/dev/null
+git -C "${WORK_REPO}" config user.email "test@example.com"
+git -C "${WORK_REPO}" config user.name "Test"
+
+# Initial commit so the repo has a HEAD
+echo "initial" > "${WORK_REPO}/readme.txt"
+git -C "${WORK_REPO}" add readme.txt
+git -C "${WORK_REPO}" commit -m "initial" -q
+git -C "${WORK_REPO}" push origin HEAD -q 2>/dev/null
+
+INITIAL_SHA="$(git -C "${WORK_REPO}" rev-parse HEAD)"
+
+# Make a dirty change (tracked file, modified)
+echo "dirty change" >> "${WORK_REPO}/readme.txt"
+
+# Write a synthetic projects.json pointing at this project
+cat > "${PROJECTS_JSON}" <<EOF
+{
+  "projects": {
+    "test-project": {
+      "name": "test-project",
+      "github_repo": "file://${BARE_REPO}",
+      "project_dir": "${WORK_REPO}",
+      "deploy_type": "nginx",
+      "task_backend": "github"
+    }
+  }
+}
+EOF
+
+mkdir -p "${STAGING_DIR}"
+
+# ── Test 1: --no-snapshot-commit → exit 5 ────────────────────────────────────
+
+info "Running: capture --no-snapshot-commit on dirty project"
+
+age-keygen -o "${TMPDIR_BASE}/key.txt" 2>/dev/null
+AGE_RECIPIENT="$(age-keygen -y "${TMPDIR_BASE}/key.txt" 2>/dev/null)"
+
+EXIT_CODE=0
+"${GB_BIN}" capture \
+    --no-snapshot-commit \
+    --age-recipient "${AGE_RECIPIENT}" \
+    --out "${STAGING_DIR}" \
+    2>&1 || EXIT_CODE=$?
+
+[[ "${EXIT_CODE}" -eq 5 ]] || \
+    fail "--no-snapshot-commit on dirty repo should exit 5, got ${EXIT_CODE}"
+
+pass "--no-snapshot-commit exits 5 on dirty project"
+
+# ── Test 2: default (allow snapshot commit) → exit 0, SHA pushed ─────────────
+
+info "Running: capture (default) on dirty project"
+
+BUNDLE_DIR="${TMPDIR_BASE}/bundle-out"
+mkdir -p "${BUNDLE_DIR}"
+
+"${GB_BIN}" capture \
+    --age-recipient "${AGE_RECIPIENT}" \
+    --out "${BUNDLE_DIR}" \
+    2>&1 | tee "${TMPDIR_BASE}/capture.log"
+
+[[ "${PIPESTATUS[0]}" -eq 0 ]] || fail "Default capture exited non-zero"
+
+pass "Default capture exits 0"
+
+# ── Test 3: new SHA is recorded in manifest.projects[] ───────────────────────
+
+BUNDLE="$(find "${BUNDLE_DIR}" -name 'general-backup-*.tar.zst' | head -1)"
+[[ -n "${BUNDLE}" ]] || fail "No bundle produced"
+
+EXTRACT_DIR="${TMPDIR_BASE}/extracted"
+mkdir -p "${EXTRACT_DIR}"
+tar -xf "${BUNDLE}" -C "${EXTRACT_DIR}" 2>/dev/null
+
+MANIFEST="$(find "${EXTRACT_DIR}" -name 'manifest.json' | head -1)"
+[[ -n "${MANIFEST}" ]] || fail "manifest.json not found in bundle"
+
+MANIFEST_SHA="$(python3 -c "
+import json, sys
+m = json.load(open('${MANIFEST}'))
+projects = m.get('projects', [])
+for p in projects:
+    if p.get('name') == 'test-project':
+        print(p.get('sha', ''))
+        sys.exit(0)
+print('')
+")"
+
+[[ -n "${MANIFEST_SHA}" ]] || fail "test-project not found in manifest.projects[]"
+[[ "${MANIFEST_SHA}" != "${INITIAL_SHA}" ]] || \
+    fail "manifest SHA is still the initial SHA (snapshot commit was not made)"
+
+pass "manifest.projects[] records new SHA after snapshot commit"
+
+# ── Test 4: the new SHA exists on the origin ──────────────────────────────────
+
+git -C "${BARE_REPO}" cat-file -t "${MANIFEST_SHA}" 2>/dev/null | grep -q "commit" || \
+    fail "SHA ${MANIFEST_SHA} not found on origin"
+
+pass "Snapshot commit SHA exists on origin"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "All git-sync tests passed."

--- a/tests/restore-in-docker.sh
+++ b/tests/restore-in-docker.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Round-trip restore test using Docker.
+#
+# Steps:
+#   1. Build an ubuntu:24.04 image with this repo baked in
+#   2. Run 'general-backup capture' on the current host to produce a bundle
+#   3. Copy the bundle into a container
+#   4. Inside the container: ./bootstrap.sh then general-backup restore <bundle>
+#   5. Assert:
+#      - Each manifest.projects[].name has a .git at recorded SHA
+#      - All manifest databases are listable
+#      - pm2 jlist count matches manifest.components.pm2.process_count
+#      - nginx -t is green
+#
+# Requirements: docker, age, general-backup CLI, postgres, redis on source host
+#
+# Usage:
+#   bash tests/restore-in-docker.sh [BUNDLE]
+#
+# If BUNDLE is not given, a fresh capture is run first.
+#
+# Environment:
+#   GB_BIN              — path to general-backup binary (default: bin/general-backup)
+#   GB_AGE_RECIPIENT    — X25519 public key (required if no BUNDLE given)
+#   GB_AGE_IDENTITY     — path to age private key (required)
+#   GB_DOCKER_IMAGE     — Docker image tag to build (default: gb-restore-test:latest)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GB_BIN="${GB_BIN:-${REPO_ROOT}/bin/general-backup}"
+GB_DOCKER_IMAGE="${GB_DOCKER_IMAGE:-gb-restore-test:latest}"
+TMPDIR_BASE="$(mktemp -d /tmp/gb-docker-XXXXXX)"
+
+pass()    { printf '\033[32mPASS\033[0m %s\n' "$1"; }
+fail()    { printf '\033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
+info()    { printf '     %s\n' "$1"; }
+
+cleanup() { rm -rf "${TMPDIR_BASE}"; }
+trap cleanup EXIT
+
+# ── Validate prerequisites ────────────────────────────────────────────────────
+
+command -v docker >/dev/null 2>&1 || fail "docker is not installed"
+[[ -n "${GB_AGE_IDENTITY:-}" ]] || fail "GB_AGE_IDENTITY must be set to the age private key path"
+
+# ── Step 1: Produce (or accept) a bundle ──────────────────────────────────────
+
+if [[ -n "${1:-}" ]]; then
+    BUNDLE="$1"
+    info "Using provided bundle: ${BUNDLE}"
+else
+    [[ -n "${GB_AGE_RECIPIENT:-}" ]] || fail "GB_AGE_RECIPIENT must be set to produce a bundle"
+    info "Producing fresh capture bundle"
+    BUNDLE_DIR="${TMPDIR_BASE}/bundle"
+    mkdir -p "${BUNDLE_DIR}"
+    "${GB_BIN}" capture \
+        --age-recipient "${GB_AGE_RECIPIENT}" \
+        --out "${BUNDLE_DIR}" \
+        2>&1 | tee "${TMPDIR_BASE}/capture.log"
+    BUNDLE="$(find "${BUNDLE_DIR}" -name 'general-backup-*.tar.zst' | head -1)"
+    [[ -n "${BUNDLE}" ]] || fail "Capture produced no bundle"
+fi
+
+[[ -f "${BUNDLE}" ]] || fail "Bundle not found: ${BUNDLE}"
+pass "Bundle ready: $(basename "${BUNDLE}")"
+
+# ── Step 2: Extract manifest for assertions ───────────────────────────────────
+
+MANIFEST_DIR="${TMPDIR_BASE}/manifest"
+mkdir -p "${MANIFEST_DIR}"
+tar -xf "${BUNDLE}" -C "${MANIFEST_DIR}" --wildcards '*/manifest.json' 2>/dev/null
+MANIFEST="$(find "${MANIFEST_DIR}" -name 'manifest.json' | head -1)"
+[[ -n "${MANIFEST}" ]] || fail "manifest.json not found in bundle"
+
+# Parse assertions from manifest
+read -ra PROJECT_NAMES < <(python3 -c "
+import json
+m = json.load(open('${MANIFEST}'))
+print(' '.join(p['name'] for p in m.get('projects', [])))
+")
+read -ra PROJECT_SHAS < <(python3 -c "
+import json
+m = json.load(open('${MANIFEST}'))
+print(' '.join(p.get('sha','') for p in m.get('projects', [])))
+")
+read -ra PROJECT_DIRS < <(python3 -c "
+import json
+m = json.load(open('${MANIFEST}'))
+print(' '.join(p.get('project_dir','') for p in m.get('projects', [])))
+")
+PM2_COUNT="$(python3 -c "
+import json
+m = json.load(open('${MANIFEST}'))
+print(m.get('components', {}).get('pm2', {}).get('process_count', 0))
+")"
+DB_NAMES=($(python3 -c "
+import json
+m = json.load(open('${MANIFEST}'))
+dbs = m.get('components', {}).get('postgres', {}).get('databases', [])
+print(' '.join(dbs))
+"))
+
+info "Projects to assert: ${PROJECT_NAMES[*]:-none}"
+info "Databases to assert: ${DB_NAMES[*]:-none}"
+info "PM2 count to assert: ${PM2_COUNT}"
+
+# ── Step 3: Build Docker image ────────────────────────────────────────────────
+
+DOCKERFILE="${TMPDIR_BASE}/Dockerfile"
+cat > "${DOCKERFILE}" <<'EOF'
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -q && apt-get install -y -q \
+    sudo git curl ca-certificates lsb-release python3 \
+    && rm -rf /var/lib/apt/lists/*
+RUN useradd -m -u 1000 -s /bin/bash bot && \
+    echo "bot ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/bot && \
+    chmod 0440 /etc/sudoers.d/bot
+WORKDIR /home/bot/projects/general-backup
+COPY . .
+RUN chown -R bot:bot /home/bot
+USER bot
+EOF
+
+info "Building Docker image ${GB_DOCKER_IMAGE}"
+docker build \
+    -t "${GB_DOCKER_IMAGE}" \
+    -f "${DOCKERFILE}" \
+    "${REPO_ROOT}" \
+    2>&1 | tail -5
+
+pass "Docker image built"
+
+# ── Step 4: Run restore in container ─────────────────────────────────────────
+
+CONTAINER_BUNDLE="/tmp/$(basename "${BUNDLE}")"
+CONTAINER_KEY="/tmp/age-key.txt"
+
+info "Running restore inside container"
+RESTORE_LOG="${TMPDIR_BASE}/restore.log"
+
+docker run --rm \
+    -v "${BUNDLE}:${CONTAINER_BUNDLE}:ro" \
+    -v "${GB_AGE_IDENTITY}:${CONTAINER_KEY}:ro" \
+    --privileged \
+    "${GB_DOCKER_IMAGE}" \
+    bash -c "
+        set -euo pipefail
+        cd /home/bot/projects/general-backup
+        sudo bash bootstrap.sh
+        general-backup restore '${CONTAINER_BUNDLE}' --age-identity '${CONTAINER_KEY}'
+    " 2>&1 | tee "${RESTORE_LOG}"
+
+RESTORE_EXIT="${PIPESTATUS[0]}"
+[[ "${RESTORE_EXIT}" -eq 0 ]] || fail "restore exited ${RESTORE_EXIT}"
+pass "Restore completed with exit 0"
+
+# ── Step 5: Assertions inside container ──────────────────────────────────────
+
+info "Running post-restore assertions"
+
+ASSERT_SCRIPT="${TMPDIR_BASE}/assert.sh"
+{
+    echo "#!/usr/bin/env bash"
+    echo "set -euo pipefail"
+    echo "FAILURES=()"
+
+    # 5a: Each project has .git at recorded SHA
+    for i in "${!PROJECT_NAMES[@]}"; do
+        name="${PROJECT_NAMES[$i]}"
+        sha="${PROJECT_SHAS[$i]}"
+        dir="${PROJECT_DIRS[$i]}"
+        echo "if [[ -d '${dir}/.git' ]]; then"
+        echo "    actual=\$(git -C '${dir}' rev-parse HEAD 2>/dev/null || echo missing)"
+        echo "    if [[ \"\$actual\" != '${sha}' ]]; then"
+        echo "        FAILURES+=(\"${name}: HEAD=\$actual want ${sha}\")"
+        echo "    fi"
+        echo "else"
+        echo "    FAILURES+=(\"${name}: .git missing at ${dir}\")"
+        echo "fi"
+    done
+
+    # 5b: Databases listable
+    for db in "${DB_NAMES[@]}"; do
+        echo "if ! psql -U postgres -lqt 2>/dev/null | grep -qw '${db}'; then"
+        echo "    FAILURES+=(\"database not listable: ${db}\")"
+        echo "fi"
+    done
+
+    # 5c: PM2 process count matches
+    if [[ "${PM2_COUNT}" -gt 0 ]]; then
+        echo "actual_pm2=\$(pm2 jlist 2>/dev/null | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)"
+        echo "if [[ \"\$actual_pm2\" -ne '${PM2_COUNT}' ]]; then"
+        echo "    FAILURES+=(\"pm2 count: got \$actual_pm2 want ${PM2_COUNT}\")"
+        echo "fi"
+    fi
+
+    # 5d: nginx -t
+    echo "if ! nginx -t 2>/dev/null; then"
+    echo "    FAILURES+=(\"nginx -t failed\")"
+    echo "fi"
+
+    echo "if [[ \${#FAILURES[@]} -gt 0 ]]; then"
+    echo "    printf 'ASSERTION FAILED: %s\n' \"\${FAILURES[@]}\""
+    echo "    exit 1"
+    echo "fi"
+    echo "echo 'All assertions passed'"
+} > "${ASSERT_SCRIPT}"
+chmod +x "${ASSERT_SCRIPT}"
+
+docker run --rm \
+    -v "${BUNDLE}:${CONTAINER_BUNDLE}:ro" \
+    -v "${GB_AGE_IDENTITY}:${CONTAINER_KEY}:ro" \
+    -v "${ASSERT_SCRIPT}:/tmp/assert.sh:ro" \
+    --privileged \
+    "${GB_DOCKER_IMAGE}" \
+    bash -c "
+        sudo bash bootstrap.sh >/dev/null 2>&1
+        general-backup restore '${CONTAINER_BUNDLE}' --age-identity '${CONTAINER_KEY}' >/dev/null 2>&1
+        sudo bash /tmp/assert.sh
+    " 2>&1
+
+ASSERT_EXIT="${PIPESTATUS[0]}"
+[[ "${ASSERT_EXIT}" -eq 0 ]] || fail "Post-restore assertions failed (exit ${ASSERT_EXIT})"
+
+pass "All post-restore assertions passed"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "All restore-in-docker tests passed."

--- a/tests/smoke-capture.sh
+++ b/tests/smoke-capture.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Smoke test for 'general-backup capture'.
+#
+# Tests:
+#   1. dry-run exits 0 and prints each expected phase
+#   2. real capture produces a valid .tar.zst bundle
+#   3. 'general-backup verify' passes on the bundle
+#   4. No plaintext secret patterns appear in the cleartext bundle files
+#
+# Usage:
+#   bash tests/smoke-capture.sh
+#
+# Environment:
+#   GB_AGE_RECIPIENT  — X25519 public key for encryption. If unset, a
+#                       throw-away key is generated for the test run.
+#   GB_BIN            — path to general-backup binary (default: bin/general-backup)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GB_BIN="${GB_BIN:-${REPO_ROOT}/bin/general-backup}"
+TMPDIR_BASE="$(mktemp -d /tmp/gb-smoke-XXXXXX)"
+KEY_FILE="${TMPDIR_BASE}/test.key"
+BUNDLE_DIR="${TMPDIR_BASE}/bundles"
+
+pass() { printf '\033[32mPASS\033[0m %s\n' "$1"; }
+fail() { printf '\033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
+info() { printf '     %s\n' "$1"; }
+
+cleanup() { rm -rf "${TMPDIR_BASE}"; }
+trap cleanup EXIT
+
+# ── Setup ──────────────────────────────────────────────────────────────────────
+
+mkdir -p "${BUNDLE_DIR}"
+
+if [[ -z "${GB_AGE_RECIPIENT:-}" ]]; then
+    info "No GB_AGE_RECIPIENT set — generating ephemeral age key for test"
+    age-keygen -o "${KEY_FILE}" 2>/dev/null
+    GB_AGE_RECIPIENT="$(age-keygen -y "${KEY_FILE}" 2>/dev/null)"
+    GB_AGE_IDENTITY="${KEY_FILE}"
+else
+    GB_AGE_IDENTITY="${GB_AGE_IDENTITY:-}"
+fi
+
+EXPECTED_PHASES=(
+    preflight git-sync inventory packages system nginx cron
+    postgres redis pm2 state secrets checksums package
+)
+
+# ── Test 1: dry-run exits 0 and mentions all capture phases ───────────────────
+
+info "Running: capture --dry-run"
+DRY_OUTPUT="$("${GB_BIN}" capture --dry-run --age-recipient "${GB_AGE_RECIPIENT}" 2>&1)" || \
+    fail "dry-run exited non-zero"
+
+for phase in "${EXPECTED_PHASES[@]}"; do
+    echo "${DRY_OUTPUT}" | grep -qi "${phase}" || \
+        fail "dry-run output missing phase: ${phase}"
+done
+pass "dry-run exits 0 and mentions all phases"
+
+# ── Test 2: real capture produces a .tar.zst bundle ──────────────────────────
+
+info "Running: real capture into ${BUNDLE_DIR}"
+"${GB_BIN}" capture \
+    --age-recipient "${GB_AGE_RECIPIENT}" \
+    --out "${BUNDLE_DIR}" \
+    2>&1 | tee "${TMPDIR_BASE}/capture.log"
+
+BUNDLE="$(find "${BUNDLE_DIR}" -name 'general-backup-*.tar.zst' | head -1)"
+[[ -n "${BUNDLE}" ]] || fail "No bundle produced in ${BUNDLE_DIR}"
+[[ -f "${BUNDLE}" ]] || fail "Bundle path is not a file: ${BUNDLE}"
+pass "real capture produced bundle: $(basename "${BUNDLE}")"
+
+# ── Test 3: verify passes ─────────────────────────────────────────────────────
+
+info "Running: verify on $(basename "${BUNDLE}")"
+VERIFY_ARGS=("${BUNDLE}")
+[[ -n "${GB_AGE_IDENTITY:-}" ]] && VERIFY_ARGS+=("--age-identity" "${GB_AGE_IDENTITY}")
+
+"${GB_BIN}" verify "${VERIFY_ARGS[@]}" 2>&1 | tee "${TMPDIR_BASE}/verify.log"
+VERIFY_EXIT="${PIPESTATUS[0]}"
+[[ "${VERIFY_EXIT}" -eq 0 ]] || fail "verify exited ${VERIFY_EXIT}"
+pass "verify passes on produced bundle"
+
+# ── Test 4: no plaintext secrets in the unencrypted portion ──────────────────
+
+SECRET_PATTERN='ghp_|gho_|sk-[a-zA-Z0-9]{20,}|password\s*=|BEGIN [A-Z]+ PRIVATE KEY'
+EXTRACT_DIR="${TMPDIR_BASE}/extracted"
+mkdir -p "${EXTRACT_DIR}"
+
+info "Extracting bundle to scan for plaintext secrets"
+tar -xf "${BUNDLE}" -C "${EXTRACT_DIR}" 2>/dev/null
+
+HITS=()
+while IFS= read -r -d '' f; do
+    # Skip secrets.age — that's where secrets are supposed to live
+    [[ "${f}" == *secrets.age ]] && continue
+    # Binary files can contain random byte patterns; scan only text-like files
+    if file "${f}" | grep -qE 'text|JSON|script'; then
+        if grep -qEi "${SECRET_PATTERN}" "${f}" 2>/dev/null; then
+            HITS+=("${f#${EXTRACT_DIR}/}")
+        fi
+    fi
+done < <(find "${EXTRACT_DIR}" -type f -print0)
+
+if [[ ${#HITS[@]} -gt 0 ]]; then
+    info "Plaintext secret patterns found in:"
+    for h in "${HITS[@]}"; do
+        info "  ${h}"
+    done
+    fail "Secret patterns found outside secrets.age (${#HITS[@]} file(s))"
+fi
+pass "No plaintext secret patterns outside secrets.age"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "All smoke-capture tests passed."


### PR DESCRIPTION
## Description

Adds the three integration test scripts and updates the Makefile with corresponding targets.

**tests/smoke-capture.sh**
- Runs `capture --dry-run`, asserts exit 0 and all 14 phases appear in output
- Runs a real capture into `/tmp`, asserts a `.tar.zst` bundle is produced
- Runs `general-backup verify` on the bundle, asserts exit 0
- Extracts the bundle and greps every cleartext file for secret patterns (`ghp_|gho_|sk-...|password=|BEGIN ... PRIVATE KEY`), asserts zero hits outside `secrets.age`
- Generates a throw-away age key if `GB_AGE_RECIPIENT` is not set

**tests/git-sync.sh**
- Creates a temp project with a local bare-repo origin (no GitHub I/O)
- Makes a dirty tracked-file change
- Asserts `capture --no-snapshot-commit` exits 5
- Asserts `capture` (default) exits 0
- Asserts `manifest.projects[].sha` is updated (different from pre-dirty SHA)
- Asserts the new SHA exists on the origin bare repo

**tests/restore-in-docker.sh**
- Builds an `ubuntu:24.04` Docker image with the repo baked in
- Accepts an existing bundle or produces a fresh capture
- Runs `./bootstrap.sh && general-backup restore <bundle>` inside the container
- Asserts: each `manifest.projects[].name` has `.git` at the recorded SHA, all databases are listable (`psql -lqt`), `pm2 jlist` count matches manifest, `nginx -t` passes

**Makefile**
- Added `git-sync` and `docker-restore` targets
- Updated `help` text

Closes GH-28