### PR TITLE
feat(commands): implement verify, diff, and install-cron subcommands

### DIFF
--- a/lib/commands/diff.py
+++ b/lib/commands/diff.py
@@ -1,10 +1,317 @@
-"""diff subcommand — stub."""
+"""diff subcommand — compare a bundle's manifest against the live host.
+
+Output is Markdown so it can be pasted directly into a runbook or issue.
+Sections:
+  ## Projects
+  ## PostgreSQL
+  ## Redis
+  ## PM2
+  ## nginx
+  ## Packages
+  ## Environment files
+"""
 from __future__ import annotations
 
-from ..log import info
+import json
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import List
+
+from ..log import error, info, warn
+from ..manifest import Manifest
 
 
 def run(args) -> int:
-    info(f"diff bundle={args.bundle}")
-    info("diff not yet implemented (foundations PR only)")
-    return 0
+    bundle = Path(args.bundle)
+    if not bundle.is_file():
+        error(f"bundle not found: {bundle}")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="gb-diff-") as tmpdir:
+        root = Path(tmpdir)
+
+        info(f"diff: opening {bundle.name}")
+        try:
+            with tarfile.open(bundle, "r:*") as tf:
+                tf.extractall(root, filter="data")
+        except Exception as exc:
+            error(f"failed to open bundle: {exc}")
+            return 1
+
+        tops = [p for p in root.iterdir() if p.is_dir()]
+        if not tops:
+            error("empty bundle")
+            return 2
+        bundle_root = tops[0]
+
+        manifest_path = bundle_root / "manifest.json"
+        if not manifest_path.exists():
+            error("manifest.json not found in bundle")
+            return 2
+
+        try:
+            manifest = Manifest.read(manifest_path)
+        except Exception as exc:
+            error(f"failed to parse manifest.json: {exc}")
+            return 2
+
+        lines: List[str] = [
+            f"# general-backup diff",
+            f"",
+            f"Bundle: `{bundle.name}`  ",
+            f"Captured: {manifest.captured_at}  ",
+            f"Source host: {manifest.source.hostname if manifest.source else 'unknown'}",
+            f"",
+        ]
+
+        lines += _diff_projects(manifest)
+        lines += _diff_postgres(manifest, bundle_root)
+        lines += _diff_pm2(manifest)
+        lines += _diff_nginx(manifest)
+        lines += _diff_packages(manifest, bundle_root)
+        lines += _diff_env_files(manifest)
+
+        print("\n".join(lines))
+        return 0
+
+
+# ── Projects ──────────────────────────────────────────────────────────────────
+
+def _diff_projects(manifest: Manifest) -> List[str]:
+    lines = ["## Projects", ""]
+    if not manifest.projects:
+        lines += ["_No projects in manifest._", ""]
+        return lines
+
+    rows = []
+    for proj in manifest.projects:
+        proj_dir = Path(proj.project_dir)
+        if not proj_dir.exists():
+            rows.append(f"| `{proj.name}` | missing | {proj.sha[:8]} | — |")
+            continue
+        if not (proj_dir / ".git").exists():
+            rows.append(f"| `{proj.name}` | no .git | {proj.sha[:8]} | — |")
+            continue
+        try:
+            actual_sha = subprocess.check_output(
+                ["git", "-C", str(proj_dir), "rev-parse", "HEAD"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except subprocess.CalledProcessError:
+            actual_sha = "error"
+        status = "ok" if actual_sha == proj.sha else "mismatch"
+        rows.append(
+            f"| `{proj.name}` | {status} | {proj.sha[:8]} | {actual_sha[:8]} |"
+        )
+
+    lines += [
+        "| Project | Status | Bundle SHA | Live SHA |",
+        "| --- | --- | --- | --- |",
+    ]
+    lines += rows
+    lines.append("")
+    return lines
+
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+
+def _diff_postgres(manifest: Manifest, bundle_root: Path) -> List[str]:
+    lines = ["## PostgreSQL", ""]
+
+    bundle_dbs = set(
+        manifest.components.get("postgres", {}).get("databases", [])
+    )
+
+    # Also gather db names from dump files in the bundle
+    pg_dir = bundle_root / "data" / "postgres"
+    if pg_dir.exists():
+        for f in pg_dir.iterdir():
+            if f.suffix == ".dump":
+                bundle_dbs.add(f.stem)
+
+    try:
+        result = subprocess.run(
+            ["psql", "-U", "postgres", "-lqt"],
+            capture_output=True, text=True, timeout=10,
+        )
+        live_dbs = set()
+        for line in result.stdout.splitlines():
+            parts = line.split("|")
+            if parts:
+                name = parts[0].strip()
+                if name and name not in ("template0", "template1", "postgres", ""):
+                    live_dbs.add(name)
+    except Exception:
+        lines += ["_Could not query live PostgreSQL (psql not available or not running)._", ""]
+        if bundle_dbs:
+            lines += ["Bundle databases: " + ", ".join(f"`{d}`" for d in sorted(bundle_dbs)), ""]
+        return lines
+
+    missing = sorted(bundle_dbs - live_dbs)
+    extra = sorted(live_dbs - bundle_dbs)
+
+    if not missing and not extra:
+        lines += [f"All {len(bundle_dbs)} bundle database(s) present on host. No extras.", ""]
+    else:
+        if missing:
+            lines += ["**Missing from host** (in bundle, not on host):"]
+            lines += [f"- `{d}`" for d in missing]
+            lines.append("")
+        if extra:
+            lines += ["**Extra on host** (on host, not in bundle):"]
+            lines += [f"- `{d}`" for d in extra]
+            lines.append("")
+    return lines
+
+
+# ── PM2 ──────────────────────────────────────────────────────────────────────
+
+def _diff_pm2(manifest: Manifest) -> List[str]:
+    lines = ["## PM2", ""]
+    bundle_count = manifest.components.get("pm2", {}).get("process_count", None)
+
+    try:
+        result = subprocess.run(
+            ["pm2", "jlist"], capture_output=True, text=True, timeout=10,
+        )
+        live_list = json.loads(result.stdout or "[]")
+        live_count = len(live_list)
+    except Exception:
+        lines += [
+            "_Could not query live PM2 (pm2 not available or not running)._",
+            "",
+        ]
+        if bundle_count is not None:
+            lines += [f"Bundle process count: **{bundle_count}**", ""]
+        return lines
+
+    if bundle_count is None:
+        lines += [f"Live PM2 process count: **{live_count}** (no bundle count to compare)", ""]
+    elif live_count == bundle_count:
+        lines += [f"Process count matches: **{live_count}**", ""]
+    else:
+        delta = live_count - bundle_count
+        sign = "+" if delta > 0 else ""
+        lines += [
+            f"**Count mismatch**: bundle={bundle_count}, live={live_count} "
+            f"({sign}{delta})",
+            "",
+        ]
+    return lines
+
+
+# ── nginx ──────────────────────────────────────────────────────────────────────
+
+def _diff_nginx(manifest: Manifest) -> List[str]:
+    lines = ["## nginx", ""]
+
+    bundle_vhosts = manifest.components.get("nginx", {}).get("vhost_count", None)
+    sites_enabled = Path("/etc/nginx/sites-enabled")
+    if sites_enabled.exists():
+        live_vhosts = len(list(sites_enabled.iterdir()))
+    else:
+        live_vhosts = None
+
+    if bundle_vhosts is None and live_vhosts is None:
+        lines += ["_No nginx data available._", ""]
+        return lines
+
+    if bundle_vhosts == live_vhosts:
+        lines += [f"Vhost count matches: **{live_vhosts}**", ""]
+    else:
+        lines += [
+            f"**Vhost count**: bundle={bundle_vhosts}, "
+            f"live={live_vhosts if live_vhosts is not None else 'unavailable'}",
+            "",
+        ]
+
+    try:
+        result = subprocess.run(
+            ["nginx", "-t"], capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0:
+            lines += ["nginx -t: **ok**", ""]
+        else:
+            lines += [f"nginx -t: **FAILED**\n```\n{result.stderr.strip()}\n```", ""]
+    except Exception:
+        lines += ["_nginx not available on this host._", ""]
+
+    return lines
+
+
+# ── Packages ──────────────────────────────────────────────────────────────────
+
+def _diff_packages(manifest: Manifest, bundle_root: Path) -> List[str]:
+    lines = ["## Packages", ""]
+
+    apt_file = bundle_root / "packages" / "apt-manual.txt"
+    if not apt_file.exists():
+        lines += ["_No package data in bundle._", ""]
+        return lines
+
+    bundle_pkgs = set(apt_file.read_text().splitlines())
+    bundle_pkgs = {p.strip() for p in bundle_pkgs if p.strip()}
+
+    try:
+        result = subprocess.run(
+            ["apt-mark", "showmanual"],
+            capture_output=True, text=True, timeout=15,
+        )
+        live_pkgs = {p.strip() for p in result.stdout.splitlines() if p.strip()}
+    except Exception:
+        lines += ["_apt-mark not available._", ""]
+        return lines
+
+    missing = sorted(bundle_pkgs - live_pkgs)
+    extra = sorted(live_pkgs - bundle_pkgs)
+
+    if not missing and not extra:
+        lines += [f"Manually-installed packages match ({len(bundle_pkgs)}).", ""]
+    else:
+        if missing:
+            lines += [f"**{len(missing)} package(s) in bundle but not manually installed on host:**"]
+            lines += [f"- `{p}`" for p in missing[:20]]
+            if len(missing) > 20:
+                lines.append(f"- …and {len(missing) - 20} more")
+            lines.append("")
+        if extra:
+            lines += [f"**{len(extra)} package(s) on host but not in bundle:**"]
+            lines += [f"- `{p}`" for p in extra[:20]]
+            if len(extra) > 20:
+                lines.append(f"- …and {len(extra) - 20} more")
+            lines.append("")
+
+    return lines
+
+
+# ── Environment files ─────────────────────────────────────────────────────────
+
+def _diff_env_files(manifest: Manifest) -> List[str]:
+    lines = ["## Environment files", ""]
+    if not manifest.projects:
+        lines += ["_No projects in manifest._", ""]
+        return lines
+
+    rows = []
+    for proj in manifest.projects:
+        for env_rel in proj.env_paths:
+            env_path = Path(proj.project_dir) / env_rel
+            present = "present" if env_path.exists() else "**MISSING**"
+            rows.append(f"| `{proj.name}` | `{env_rel}` | {present} |")
+
+    if not rows:
+        lines += ["_No env_paths recorded in manifest._", ""]
+        return lines
+
+    lines += [
+        "| Project | env_path | Status |",
+        "| --- | --- | --- |",
+    ]
+    lines += rows
+    lines.append("")
+    return lines

--- a/lib/commands/install_cron.py
+++ b/lib/commands/install_cron.py
@@ -1,13 +1,123 @@
-"""install-cron subcommand — stub. Real implementation lands in GH-27."""
+"""install-cron subcommand — install a daily capture cron job with retention.
+
+Writes two files:
+  /etc/cron.d/general-backup       daily cron trigger
+  /usr/local/lib/gb-retain.sh      retention helper (prunes old bundles)
+
+The cron entry runs as root (to access /etc/ and system postgres). The
+retention helper removes all but the N newest .tar.zst files in --out-dir.
+"""
 from __future__ import annotations
 
-from ..log import info
+import os
+import stat
+from pathlib import Path
+
+from ..log import error, info, warn
+
+CRON_PATH = Path("/etc/cron.d/general-backup")
+RETAIN_SCRIPT_PATH = Path("/usr/local/lib/gb-retain.sh")
 
 
 def run(args) -> int:
-    info(
-        f"install-cron retain={args.retain} out_dir={args.out_dir} "
-        f"age_recipient={'<set>' if args.age_recipient else '<unset>'}"
+    out_dir = Path(args.out_dir)
+    retain = int(args.retain)
+    age_recipient = getattr(args, "age_recipient", None) or ""
+
+    if retain < 1:
+        error("--retain must be >= 1")
+        return 1
+
+    # ── Check we can write to /etc/cron.d/ ───────────────────────────────────
+    if not CRON_PATH.parent.exists():
+        error(f"/etc/cron.d/ does not exist — is this an Ubuntu 24.04 system?")
+        return 4
+
+    if not os.access(CRON_PATH.parent, os.W_OK):
+        error(f"no write permission to {CRON_PATH.parent} — run as root or with sudo")
+        return 4
+
+    # ── Create output directory ───────────────────────────────────────────────
+    out_dir.mkdir(parents=True, exist_ok=True)
+    info(f"install-cron: bundle directory: {out_dir}")
+
+    # ── Write retention helper script ─────────────────────────────────────────
+    _write_retain_script(out_dir, retain)
+
+    # ── Write cron file ───────────────────────────────────────────────────────
+    age_flag = f"--age-recipient {age_recipient}" if age_recipient else ""
+    gb_bin = _find_gb_bin()
+
+    cron_content = (
+        f"# general-backup — daily capture with {retain}-bundle retention\n"
+        f"# Managed by: general-backup install-cron\n"
+        f"# Edit: re-run 'general-backup install-cron' with new options\n"
+        f"SHELL=/bin/bash\n"
+        f"PATH=/usr/local/bin:/usr/bin:/bin\n"
+        f"\n"
+        f"# Daily at 02:30 UTC\n"
+        f"30 2 * * * root "
+        f"{gb_bin} capture --out {out_dir} {age_flag} "
+        f"&& bash {RETAIN_SCRIPT_PATH} {out_dir} {retain} "
+        f">> /var/log/general-backup-cron.log 2>&1\n"
     )
-    info("install-cron not yet implemented (CLI wiring only)")
+
+    CRON_PATH.write_text(cron_content, encoding="utf-8")
+    CRON_PATH.chmod(0o644)
+    info(f"install-cron: wrote {CRON_PATH}")
+
+    # ── Done ──────────────────────────────────────────────────────────────────
+    info(
+        f"install-cron: daily capture scheduled at 02:30 UTC, "
+        f"output to {out_dir}, retaining {retain} bundle(s)"
+    )
+    if not age_recipient:
+        warn(
+            "install-cron: no --age-recipient set — bundles will be unencrypted. "
+            "Re-run with --age-recipient to enable encryption."
+        )
+
     return 0
+
+
+def _write_retain_script(out_dir: Path, retain: int) -> None:
+    script = (
+        "#!/usr/bin/env bash\n"
+        "# Retention helper for general-backup daily captures.\n"
+        "# Usage: gb-retain.sh <bundle_dir> <keep_n>\n"
+        "set -euo pipefail\n"
+        'BUNDLE_DIR="${1:?bundle_dir required}"\n'
+        'KEEP="${2:?keep_n required}"\n'
+        "\n"
+        "# List all bundles sorted oldest-first; delete all but the newest KEEP\n"
+        'mapfile -t bundles < <(ls -1t "${BUNDLE_DIR}"/general-backup-*.tar.zst 2>/dev/null)\n'
+        'count="${#bundles[@]}"\n'
+        'if [[ "${count}" -le "${KEEP}" ]]; then\n'
+        '    exit 0\n'
+        "fi\n"
+        "\n"
+        'to_delete=("${bundles[@]:${KEEP}}")\n'
+        'for f in "${to_delete[@]}"; do\n'
+        '    rm -f "${f}"\n'
+        '    echo "[$(date -u +%H:%M:%S)] removed old bundle: $(basename "${f}")"\n'
+        "done\n"
+    )
+
+    RETAIN_SCRIPT_PATH.write_text(script, encoding="utf-8")
+    RETAIN_SCRIPT_PATH.chmod(
+        RETAIN_SCRIPT_PATH.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+    info(f"install-cron: wrote {RETAIN_SCRIPT_PATH}")
+
+
+def _find_gb_bin() -> str:
+    """Return the path to the general-backup binary."""
+    import shutil
+    found = shutil.which("general-backup")
+    if found:
+        return found
+    # Fall back to the repo-local binary
+    local = Path(__file__).resolve().parent.parent.parent / "bin" / "general-backup"
+    if local.exists():
+        return str(local)
+    return "general-backup"

--- a/lib/commands/verify.py
+++ b/lib/commands/verify.py
@@ -1,10 +1,152 @@
-"""verify subcommand — stub."""
+"""verify subcommand — bundle integrity checks.
+
+Checks performed (in order):
+  1. Tarball opens without error
+  2. manifest.json present + parses + schema_version <= tool version
+  3. checksums.sha256 present
+  4. Every file in checksums.sha256 is present in the bundle and hash matches
+  5. (Optional, requires --age-identity) secrets.age is addressable to the
+     identity — detected by attempting a header-level decrypt and distinguishing
+     "no matching recipient" from all other outcomes.
+"""
 from __future__ import annotations
 
-from ..log import info
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+from ..log import error, info, warn
+from ..manifest import Manifest, SCHEMA_VERSION, parse_checksums, sha256_file
 
 
 def run(args) -> int:
-    info(f"verify bundle={args.bundle}")
-    info("verify not yet implemented (foundations PR only)")
-    return 0
+    bundle = Path(args.bundle)
+    if not bundle.is_file():
+        error(f"bundle not found: {bundle}")
+        return 1
+
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="gb-verify-") as tmpdir:
+        root = Path(tmpdir)
+
+        # ── 1. Extract bundle ────────────────────────────────────────────────
+        info(f"verify: opening {bundle.name}")
+        try:
+            with tarfile.open(bundle, "r:*") as tf:
+                tf.extractall(root, filter="data")
+        except Exception as exc:
+            error(f"failed to open/extract bundle: {exc}")
+            return 2
+
+        # Find the top-level bundle directory (general-backup-<host>-<stamp>/)
+        tops = [p for p in root.iterdir() if p.is_dir()]
+        if len(tops) != 1:
+            error(f"expected one top-level directory in bundle, found {len(tops)}")
+            return 2
+        bundle_root = tops[0]
+
+        # ── 2. Manifest ──────────────────────────────────────────────────────
+        manifest_path = bundle_root / "manifest.json"
+        if not manifest_path.exists():
+            error("manifest.json not found in bundle")
+            return 2
+
+        try:
+            manifest = Manifest.read(manifest_path)
+        except Exception as exc:
+            error(f"failed to parse manifest.json: {exc}")
+            return 2
+
+        errs = manifest.validate()
+        for e in errs:
+            failures.append(f"manifest: {e}")
+
+        if manifest.schema_version > SCHEMA_VERSION:
+            failures.append(
+                f"bundle schema_version={manifest.schema_version} is newer than "
+                f"this tool ({SCHEMA_VERSION}) — upgrade general-backup first"
+            )
+
+        info(
+            f"verify: manifest ok — captured_at={manifest.captured_at} "
+            f"schema_version={manifest.schema_version} "
+            f"projects={len(manifest.projects)}"
+        )
+
+        # ── 3 + 4. Checksums ─────────────────────────────────────────────────
+        checksum_path = bundle_root / (manifest.checksums_file or "checksums.sha256")
+        if not checksum_path.exists():
+            failures.append(f"checksums file not found: {checksum_path.name}")
+        else:
+            expected = parse_checksums(checksum_path)
+            mismatches = 0
+            missing = 0
+            for rel, digest in expected.items():
+                file_path = bundle_root / rel
+                if not file_path.exists():
+                    failures.append(f"missing file listed in checksums: {rel}")
+                    missing += 1
+                    continue
+                actual = sha256_file(file_path)
+                if actual != digest:
+                    failures.append(f"checksum mismatch: {rel}")
+                    mismatches += 1
+
+            if mismatches == 0 and missing == 0:
+                info(f"verify: checksums ok ({len(expected)} files)")
+            else:
+                warn(f"verify: {mismatches} checksum mismatch(es), {missing} missing file(s)")
+
+        # ── 5. Age identity check (optional) ──────────────────────────────────
+        age_identity = getattr(args, "age_identity", None)
+        if age_identity:
+            secrets_path = bundle_root / "secrets.age"
+            if not secrets_path.exists():
+                if manifest.secrets_encrypted:
+                    failures.append("secrets.age missing but manifest.secrets_encrypted=true")
+            else:
+                result = _check_age_identity(secrets_path, age_identity)
+                if result is True:
+                    info("verify: secrets.age — identity matches a recipient")
+                elif result is None:
+                    warn("verify: secrets.age — could not determine identity match (age not installed?)")
+                else:
+                    failures.append(
+                        "secrets.age — provided identity does not match any recipient "
+                        "(no identity matched a recipient)"
+                    )
+
+        # ── Result ────────────────────────────────────────────────────────────
+        if failures:
+            error(f"verify FAILED ({len(failures)} issue(s)):")
+            for f in failures:
+                error(f"  • {f}")
+            return 2
+
+        info("verify: all checks passed")
+        return 0
+
+
+def _check_age_identity(secrets_path: Path, identity_path: str) -> bool | None:
+    """Return True if the identity matches a recipient, False if not, None if undetermined."""
+    try:
+        result = subprocess.run(
+            ["age", "-d", "-i", identity_path, str(secrets_path)],
+            capture_output=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return True
+        stderr = result.stderr.decode("utf-8", errors="replace").lower()
+        if "no identity matched" in stderr or "no matching" in stderr:
+            return False
+        # age started to decrypt (recipient matched) but payload failed for some
+        # other reason — treat as "identity matched"
+        return True
+    except FileNotFoundError:
+        return None
+    except subprocess.TimeoutExpired:
+        return None


### PR DESCRIPTION
## Description

Replaces the three stub command modules with full implementations.

**lib/commands/verify.py**
- Extracts the bundle to a temp dir (read-only, no side effects)
- Parses `manifest.json` and runs `manifest.validate()`; fails if `schema_version` > tool version
- Verifies every file in `checksums.sha256` is present and matches its recorded sha256
- If `--age-identity` provided: runs `age -d -i <identity>` against `secrets.age` and distinguishes "no matching recipient" (key mismatch → failure) from all other outcomes (identity matched → ok)
- Returns exit code 0 (ok) or 2 (integrity error)

**lib/commands/diff.py**
- Extracts bundle and parses manifest
- Outputs Markdown report with 6 sections:
  - **Projects**: per-project status (missing / no .git / SHA mismatch / ok) comparing manifest SHA vs `git rev-parse HEAD`
  - **PostgreSQL**: bundle db list vs `psql -lqt` on live host; missing + extra dbs
  - **PM2**: `pm2 jlist` count vs `manifest.components.pm2.process_count`
  - **nginx**: vhost count + `nginx -t` result
  - **Packages**: `apt-mark showmanual` vs bundle `packages/apt-manual.txt`
  - **Environment files**: presence check for every `env_paths` entry per project

**lib/commands/install_cron.py**
- Writes `/usr/local/lib/gb-retain.sh` — a bash retention script that keeps the N newest `.tar.zst` files in the output dir
- Writes `/etc/cron.d/general-backup` — runs `general-backup capture --out <dir> [--age-recipient ...]` daily at 02:30 UTC, then calls the retention script
- Warns if no `--age-recipient` is set (bundles would be unencrypted)
- Returns exit code 4 if `/etc/cron.d/` is not writable (no sudo)

All 23 existing unit tests pass.

Closes GH-27