### PR TITLE
feat(restore-agent): add restore-runbook.md and implement restore-agent subcommand

### DIFF
--- a/docs/restore-runbook.md
+++ b/docs/restore-runbook.md
@@ -1,0 +1,285 @@
+# general-backup restore runbook
+
+You are a Claude Code agent running on a fresh Ubuntu 24.04 server. Your task
+is to restore a server from a `general-backup` bundle. Follow this runbook
+exactly. Do not skip phases. Do not ask the operator unless you reach a
+decision point marked **[DECISION]**.
+
+## Environment
+
+The following environment variables are injected by `general-backup restore-agent`:
+
+- `BUNDLE_PATH` — absolute path to the `.tar.zst` bundle
+- `MANIFEST_PATH` — absolute path to `manifest.json` (already extracted)
+- `AGE_IDENTITY` — path to the age private key file (may be empty if not provided)
+- `GB_BIN` — path to the `general-backup` binary
+- `TARGET_USER` — the user to restore as (default: `bot`)
+
+## Phase order
+
+Run phases in this exact order. Each phase is a `general-backup phase <name>`
+subcommand. If a phase fails:
+- Check `/var/log/general-backup-restore.log` for the error.
+- Attempt to fix the underlying cause.
+- Re-run the phase — each phase is idempotent and done-markers prevent re-work.
+
+```
+bootstrap → packages → users → state-extract → secrets-decrypt →
+projects-clone → postgres → redis → nginx → pm2 → cron → postcheck
+```
+
+## Reading the manifest
+
+```bash
+python3 -c "import json; m=json.load(open('${MANIFEST_PATH}')); print(json.dumps(m, indent=2))"
+```
+
+Key fields:
+- `manifest.projects[]` — list of projects to clone + wire up
+- `manifest.components.pm2.process_count` — expected PM2 process count for postcheck
+- `manifest.components.postgres.databases` — expected database list
+- `manifest.toolchain` — pinned tool versions installed by bootstrap
+
+## Phase instructions
+
+### bootstrap
+
+```bash
+${GB_BIN} phase bootstrap
+```
+
+This invokes `./bootstrap.sh` which installs the full toolchain: apt packages,
+Node (NodeSource), pnpm (corepack), pm2 (npm -g), PostgreSQL 16, Redis, and
+the `claude-code` CLI.
+
+The bootstrap reads `manifest.toolchain` to pin versions. If the host already
+has matching versions, each step is a no-op.
+
+Expected: exits 0. If it fails with a package installation error, retry after
+running `sudo apt-get update`.
+
+### packages
+
+```bash
+${GB_BIN} phase packages --bundle "${BUNDLE_PATH}"
+```
+
+Applies the full `dpkg --get-selections` list from the bundle and runs
+`apt-get dselect-upgrade -y`. This replays all manually installed apt packages.
+
+Expected: exits 0. Network failures are transient — retry.
+
+### users
+
+```bash
+${GB_BIN} phase users --bundle "${BUNDLE_PATH}"
+```
+
+Ensures `${TARGET_USER}` (uid 1000) exists. Applies the `passwd.delta` and
+`group.delta` from the bundle for any non-system users captured at source.
+
+Shadow lines and sudoers entries are in `secrets.age` and are applied in
+`secrets-decrypt`.
+
+Expected: exits 0.
+
+### state-extract
+
+```bash
+${GB_BIN} phase state-extract --bundle "${BUNDLE_PATH}"
+```
+
+Extracts the four state tarballs into their home directories:
+- `state/orchestrator.tar.zst` → `~/.orchestrator/`
+- `state/claude.tar.zst` → `~/.claude/`
+- `state/config.tar.zst` → `~/.config/`
+- `state/home-dotfiles.tar.zst` → `$HOME/` (.bashrc, .profile, .gitconfig)
+
+Chowns everything to `${TARGET_USER}:${TARGET_USER}`.
+
+Expected: exits 0.
+
+### secrets-decrypt
+
+```bash
+AGE_ID="${AGE_IDENTITY}"
+${GB_BIN} phase secrets-decrypt --bundle "${BUNDLE_PATH}" ${AGE_ID:+--age-identity "${AGE_ID}"}
+```
+
+Decrypts `secrets.age` into a tmpfs staging directory and installs:
+- `~/.ssh/*` with chmod 600
+- Each project's `.env*` files at `manifest.projects[].env_paths`
+- `~/.config/gh/hosts.yml` (GitHub token)
+- PostgreSQL role password hashes loaded for the postgres phase
+- Shadow lines + sudoers.d entries
+
+[DECISION] If `AGE_IDENTITY` is empty or the identity does not match:
+- The operator must provide the age private key.
+- Ask: "I need the age private key to decrypt secrets.age. Please provide the
+  path to the key file." Pause and wait for the response.
+
+Expected: exits 0. If it fails with "no identity matched", the identity file
+is wrong — ask the operator for the correct key.
+
+### projects-clone
+
+```bash
+${GB_BIN} phase projects-clone --bundle "${BUNDLE_PATH}"
+```
+
+For each entry in `manifest.projects[]`:
+1. Creates `project_dir` if missing.
+2. `git clone <git_url> <project_dir>` or, if already exists:
+   `git -C <project_dir> fetch origin && git -C <project_dir> reset --hard <sha>`
+3. `git -C <project_dir> checkout <sha>`
+4. Places env files from secrets staging at `env_paths`.
+5. Runs `pnpm install --frozen-lockfile` (best-effort).
+
+**Decision rules:**
+- If `pnpm install` fails: log the error, mark the project as `degraded`,
+  continue to the next project. Do NOT abort.
+- If `git clone` fails (repository not found, no auth): log the error, mark
+  as `degraded`, continue.
+- If a project's `pm2_apps` list is empty in the manifest and the project
+  directory is now present, check `data/pm2/dump.pm2` in the bundle for
+  matching entries to seed pm2 for that project.
+
+Expected: exits 0 even if some projects are degraded. Degraded projects are
+listed in the output — you will need to fix them manually after the run.
+
+### postgres
+
+```bash
+${GB_BIN} phase postgres --bundle "${BUNDLE_PATH}"
+```
+
+1. Starts `pg_ctlcluster 16 main` if not running.
+2. `psql -U postgres -f data/postgres/globals.sql` — restores roles and tablespaces.
+3. For each role with a captured password hash: `ALTER ROLE <name> PASSWORD '<hash>'`.
+4. For each database in `data/postgres/`: `createdb -O postgres <name>` (skip if exists).
+5. `pg_restore --format=custom -d <db> data/postgres/<db>.dump`
+
+**Decision rules:**
+- If a database already exists with data: by default, `pg_restore` will fail
+  on duplicate objects. Check if the database should be dropped first. If
+  in doubt, ask the operator before dropping.
+- If a `.dump` file is missing for a database listed in the manifest: log a
+  warning and continue.
+
+Expected: exits 0 for all databases, or 3 (partial) if some failed.
+
+### redis
+
+```bash
+${GB_BIN} phase redis --bundle "${BUNDLE_PATH}"
+```
+
+1. Stops redis-server.
+2. Copies `data/redis/dump.rdb` to `/var/lib/redis/dump.rdb`.
+3. Sets ownership: `chown redis:redis /var/lib/redis/dump.rdb`.
+4. Applies non-default CONFIG values from `data/redis/config.json`.
+5. Starts redis-server.
+
+Expected: exits 0.
+
+### nginx
+
+```bash
+${GB_BIN} phase nginx --bundle "${BUNDLE_PATH}"
+```
+
+1. Copies `data/nginx/nginx.conf` to `/etc/nginx/nginx.conf`.
+2. Copies `data/nginx/sites-available/` to `/etc/nginx/sites-available/`.
+3. Copies `data/nginx/conf.d/` to `/etc/nginx/conf.d/`.
+4. Recreates symlinks in `/etc/nginx/sites-enabled/` from `data/nginx/sites-enabled.txt`.
+5. Runs `nginx -t && systemctl reload nginx`.
+
+**Decision rule:** If `nginx -t` fails:
+- Inspect the error. A missing SSL certificate is the most common cause.
+  SSL certificates are not in the bundle.
+- Obtain certificates via `sudo certbot --nginx -d <domain>` for each vhost.
+- Re-run this phase after certificates are in place.
+
+Expected: exits 0 with nginx active and reloaded.
+
+### pm2
+
+```bash
+sudo -u ${TARGET_USER} ${GB_BIN} phase pm2 --bundle "${BUNDLE_PATH}"
+```
+
+Runs as `${TARGET_USER}` (not root):
+1. `pm2 resurrect` from captured `dump.pm2`.
+2. Verifies `pm2 jlist | length` matches `manifest.components.pm2.process_count`.
+3. `pm2 save && pm2 startup systemd`.
+
+**Decision rule:** If `pm2 jlist | length` is less than expected:
+- Check `dump.pm2` for the missing process definitions.
+- Manually register missing processes: `pm2 start <ecosystem.config.js> --only <name>`.
+- Re-run `pm2 save`.
+
+Expected: exits 0. If count does not match after manual fix, note the
+discrepancy in the restore report.
+
+### cron
+
+```bash
+${GB_BIN} phase cron --bundle "${BUNDLE_PATH}"
+```
+
+1. Installs `data/cron/bot.crontab` via `crontab -u ${TARGET_USER}`.
+2. Copies `data/cron/etc-cron.d/*` to `/etc/cron.d/`.
+
+Expected: exits 0.
+
+### postcheck
+
+```bash
+${GB_BIN} phase postcheck --bundle "${BUNDLE_PATH}"
+```
+
+Runs all post-restore assertions:
+- `pm2 jlist` count matches manifest
+- `nginx -t` passes
+- All `manifest.components.postgres.databases` are listable
+- All `manifest.projects[].project_dir` exist and have `.git/`
+
+Produces `restore-report.md` in the current directory.
+
+Expected: exits 0. If it exits non-zero, read `restore-report.md` for the
+list of failed assertions and remediation steps.
+
+---
+
+## After the runbook completes
+
+1. Read `restore-report.md` and address any items listed as `FAILED` or `degraded`.
+2. For each degraded project: `cd <project_dir> && pnpm install && pnpm build`.
+3. For missing SSL certificates: `sudo certbot --nginx -d <domain>`.
+4. Notify the operator that restore is complete.
+5. If `--auto-confirm` was NOT set: pause here and wait for the operator to
+   confirm before exiting.
+
+---
+
+## Quick reference
+
+```bash
+# Check phase done-markers
+ls /var/lib/general-backup/state/
+
+# Force a phase to re-run (delete its marker)
+rm /var/lib/general-backup/state/<phase>.ok
+
+# View restore log
+tail -f /var/log/general-backup-restore.log
+
+# Check PM2
+pm2 jlist | python3 -c "import json,sys; procs=json.load(sys.stdin); [print(p['name'],p['pm2_env']['status']) for p in procs]"
+
+# Check nginx
+sudo nginx -t && sudo systemctl status nginx
+
+# Check postgres databases
+psql -U postgres -lqt | awk -F'|' '{print $1}' | grep -v '^\s*$'
+```

--- a/lib/commands/restore_agent.py
+++ b/lib/commands/restore_agent.py
@@ -1,10 +1,212 @@
-"""restore-agent subcommand — stub. Wired up in GH-26."""
+"""restore-agent subcommand — agent-driven restore via Claude Code.
+
+Steps:
+  1. Validate the bundle exists and is a valid tarball.
+  2. Extract manifest.json to a temp staging dir.
+  3. Run 'general-backup verify <bundle>' — abort if it fails.
+  4. Locate docs/restore-runbook.md (embedded in bundle OR repo).
+  5. Spawn a tmux session running:
+       claude --dangerously-skip-permissions -p "<runbook>"
+     with BUNDLE_PATH, MANIFEST_PATH, AGE_IDENTITY, GB_BIN, TARGET_USER injected.
+  6. Stream the agent log to stdout + /var/log/general-backup-restore.log.
+"""
 from __future__ import annotations
 
-from ..log import info
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+from ..log import error, info, warn
+
+
+_LOG_PATH = Path("/var/log/general-backup-restore.log")
+_SESSION_NAME = "gb-restore-agent"
 
 
 def run(args) -> int:
-    info(f"restore-agent bundle={args.bundle} auto_confirm={getattr(args, 'auto_confirm', False)}")
-    info("restore-agent not yet implemented (CLI wiring only)")
+    bundle = Path(args.bundle)
+    age_identity: str = getattr(args, "age_identity", None) or ""
+    auto_confirm: bool = getattr(args, "auto_confirm", False)
+
+    if not bundle.is_file():
+        error(f"bundle not found: {bundle}")
+        return 1
+
+    # ── 1. Verify bundle ──────────────────────────────────────────────────────
+    info("restore-agent: verifying bundle integrity")
+    gb_bin = _find_gb_bin()
+    verify_cmd = [gb_bin, "verify", str(bundle)]
+    if age_identity:
+        verify_cmd += ["--age-identity", age_identity]
+
+    result = subprocess.run(verify_cmd, capture_output=False)
+    if result.returncode != 0:
+        error(f"bundle verification failed (exit {result.returncode}) — aborting")
+        return 2
+
+    # ── 2. Extract manifest.json ──────────────────────────────────────────────
+    staging_dir = Path(tempfile.mkdtemp(prefix="gb-restore-agent-"))
+    info(f"restore-agent: staging dir: {staging_dir}")
+
+    try:
+        with tarfile.open(bundle, "r:*") as tf:
+            tf.extractall(staging_dir, filter="data")
+    except Exception as exc:
+        error(f"failed to extract bundle: {exc}")
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        return 2
+
+    tops = [p for p in staging_dir.iterdir() if p.is_dir()]
+    if not tops:
+        error("bundle appears empty after extraction")
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        return 2
+
+    bundle_root = tops[0]
+    manifest_path = bundle_root / "manifest.json"
+    if not manifest_path.exists():
+        error("manifest.json not found in extracted bundle")
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        return 2
+
+    info(f"restore-agent: manifest at {manifest_path}")
+
+    # ── 3. Locate runbook ─────────────────────────────────────────────────────
+    # Prefer the runbook embedded in the bundle (captured at bundle creation
+    # time); fall back to the current repo version.
+    runbook_path = bundle_root / "restore-runbook.md"
+    if not runbook_path.exists():
+        repo_runbook = Path(__file__).resolve().parent.parent.parent / "docs" / "restore-runbook.md"
+        if repo_runbook.exists():
+            runbook_path = repo_runbook
+            warn("restore-agent: runbook not found in bundle — using repo version")
+        else:
+            error("restore-runbook.md not found in bundle or repo docs/")
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            return 1
+
+    runbook_text = runbook_path.read_text(encoding="utf-8")
+    info(f"restore-agent: runbook: {runbook_path} ({len(runbook_text)} chars)")
+
+    # ── 4. Ensure log file is writable ───────────────────────────────────────
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _LOG_PATH.touch(exist_ok=True)
+    except PermissionError:
+        warn(f"restore-agent: cannot write to {_LOG_PATH} — log will be stdout only")
+
+    # ── 5. Build tmux session ─────────────────────────────────────────────────
+    if not shutil.which("tmux"):
+        error("tmux is not installed — required for restore-agent")
+        return 1
+
+    if not shutil.which("claude"):
+        error(
+            "claude CLI is not installed — run './bootstrap.sh' first to install it, "
+            "or use 'general-backup restore' for script-mode restore"
+        )
+        return 1
+
+    env = {
+        **os.environ,
+        "BUNDLE_PATH": str(bundle),
+        "MANIFEST_PATH": str(manifest_path),
+        "AGE_IDENTITY": age_identity,
+        "GB_BIN": gb_bin,
+        "TARGET_USER": getattr(args, "target_user", "bot"),
+    }
+
+    # Kill any existing session with the same name
+    subprocess.run(
+        ["tmux", "kill-session", "-t", _SESSION_NAME],
+        capture_output=True,
+    )
+
+    # The claude invocation: pipe runbook as the -p prompt, redirect output to log
+    claude_cmd = " ".join([
+        "claude",
+        "--dangerously-skip-permissions",
+        "-p", shlex_quote(runbook_text),
+    ])
+    if auto_confirm:
+        claude_cmd += " --auto-confirm"
+
+    log_cmd = f"tee -a {shlex_quote(str(_LOG_PATH))}"
+    full_cmd = f"{claude_cmd} 2>&1 | {log_cmd}"
+
+    info(f"restore-agent: spawning tmux session '{_SESSION_NAME}'")
+    result = subprocess.run(
+        [
+            "tmux", "new-session", "-d",
+            "-s", _SESSION_NAME,
+            "-x", "220", "-y", "50",
+            "--",
+            "bash", "-c", full_cmd,
+        ],
+        env=env,
+    )
+
+    if result.returncode != 0:
+        error("failed to create tmux session")
+        return 1
+
+    info(
+        f"restore-agent: agent session started. "
+        f"Attach: tmux attach -t {_SESSION_NAME}"
+    )
+    info(f"restore-agent: log streaming to {_LOG_PATH} and stdout")
+
+    # ── 6. Stream log to stdout ───────────────────────────────────────────────
+    _stream_log(_LOG_PATH, _SESSION_NAME)
+
     return 0
+
+
+def _stream_log(log_path: Path, session_name: str) -> None:
+    """Tail the log file until the tmux session exits."""
+    try:
+        proc = subprocess.Popen(
+            ["tail", "-f", str(log_path)],
+            stdout=sys.stdout,
+            stderr=subprocess.DEVNULL,
+        )
+        # Poll until the tmux session ends
+        while True:
+            check = subprocess.run(
+                ["tmux", "has-session", "-t", session_name],
+                capture_output=True,
+            )
+            if check.returncode != 0:
+                break
+            try:
+                proc.wait(timeout=2)
+                break
+            except subprocess.TimeoutExpired:
+                pass
+    except KeyboardInterrupt:
+        info("restore-agent: interrupted — agent session still running in tmux")
+    finally:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+
+
+def shlex_quote(s: str) -> str:
+    """Shell-escape a string for inclusion in a bash -c argument."""
+    import shlex
+    return shlex.quote(s)
+
+
+def _find_gb_bin() -> str:
+    found = shutil.which("general-backup")
+    if found:
+        return found
+    local = Path(__file__).resolve().parent.parent.parent / "bin" / "general-backup"
+    if local.exists():
+        return str(local)
+    return "general-backup"


### PR DESCRIPTION
## Description

Implements the agent-driven restore path (GH-26): the canonical runbook that a Claude Code agent follows, and the `restore-agent` subcommand that orchestrates the agent session.

**docs/restore-runbook.md**

The canonical machine-readable restore prompt, structured as step-by-step phase instructions for a Claude Code agent:

- Environment variables injected by `restore-agent` (`BUNDLE_PATH`, `MANIFEST_PATH`, `AGE_IDENTITY`, `GB_BIN`, `TARGET_USER`)
- Full phase order: bootstrap → packages → users → state-extract → secrets-decrypt → projects-clone → postgres → redis → nginx → pm2 → cron → postcheck
- Per-phase: exact `general-backup phase <name>` command, expected outcome, decision rules
- Decision rules for every ambiguity:
  - `pnpm install` failure → mark degraded, continue (not abort)
  - Missing `pm2_apps` in manifest → seed from `data/pm2/dump.pm2`
  - Missing database dump → warn and continue
  - nginx `nginx -t` failure → certbot guidance
  - Missing age identity → pause and ask operator
- Postcheck assertions and `restore-report.md` production
- Quick reference commands

**lib/commands/restore_agent.py**

Full implementation replacing the stub:

1. Validates bundle exists
2. Runs `general-backup verify <bundle>` — aborts on integrity failure (exit 2)
3. Extracts bundle to temp staging dir, locates `manifest.json`
4. Locates `restore-runbook.md` (embedded in bundle preferred; falls back to repo `docs/`)
5. Spawns a detached tmux session running `claude --dangerously-skip-permissions -p "<runbook>"` with all env vars injected
6. Streams the log file (`/var/log/general-backup-restore.log`) to stdout until the tmux session exits
7. Handles `--auto-confirm` flag passthrough to claude

All 23 existing unit tests pass.

Closes GH-26