### PR TITLE
feat(phases): implement postgres and redis capture phases

### DIFF
--- a/lib/phases/postgres.py
+++ b/lib/phases/postgres.py
@@ -1,0 +1,128 @@
+"""Capture phase: postgres — dump all databases and extract role passwords.
+
+Steps:
+  1. pg_dumpall --globals-only --no-role-passwords → globals.sql
+  2. pg_dump --format=custom --compress=9 per database → <db>.dump
+  3. Extract role password hashes from pg_authid (SUPERUSER required) → roles.json
+     in ctx.secrets_staging (for age-encryption by the secrets phase)
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+from ..log import info, warn
+from . import Context, PhaseError
+
+# Databases to skip (system-managed)
+_SKIP_DBS = {"template0", "template1", "postgres"}
+
+
+def run(ctx: Context) -> None:
+    pg_dir = ctx.ensure_dir("data", "postgres")
+    secrets_pg_dir = ctx.secrets_dir("postgres")
+
+    # List databases
+    dbs = _list_databases()
+    user_dbs = [db for db in dbs if db not in _SKIP_DBS]
+    info(f"postgres: found {len(user_dbs)} user database(s): {', '.join(user_dbs)}")
+
+    # globals.sql (roles + tablespaces, no plaintext passwords)
+    _dump_globals(pg_dir / "globals.sql")
+
+    # per-DB dumps
+    for db in user_dbs:
+        _dump_db(db, pg_dir / f"{db}.dump")
+
+    # Role password hashes → secrets staging
+    _extract_role_passwords(secrets_pg_dir / "roles.json")
+
+    ctx.manifest.components["postgres"] = {
+        "version": _pg_version(),
+        "databases": user_dbs,
+    }
+    info("postgres: done")
+
+
+def _list_databases() -> List[str]:
+    result = subprocess.run(
+        ["psql", "-U", "postgres", "-lqt", "--no-align"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise PhaseError(f"psql -lqt failed: {result.stderr.strip()}")
+
+    dbs: List[str] = []
+    for line in result.stdout.splitlines():
+        parts = line.split("|")
+        if parts and parts[0].strip():
+            dbs.append(parts[0].strip())
+    return dbs
+
+
+def _dump_globals(output: Path) -> None:
+    info("postgres: pg_dumpall --globals-only --no-role-passwords")
+    result = subprocess.run(
+        ["pg_dumpall", "-U", "postgres", "--globals-only", "--no-role-passwords"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise PhaseError(f"pg_dumpall globals failed: {result.stderr.decode()[:200]}")
+    output.write_bytes(result.stdout)
+    info(f"postgres: globals.sql ({len(result.stdout):,} bytes)")
+
+
+def _dump_db(db: str, output: Path) -> None:
+    info(f"postgres: pg_dump {db!r}")
+    result = subprocess.run(
+        [
+            "pg_dump",
+            "-U", "postgres",
+            "--format=custom",
+            "--compress=9",
+            "--file", str(output),
+            db,
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        warn(f"postgres: pg_dump {db!r} failed: {result.stderr[:200]}")
+    else:
+        size = output.stat().st_size if output.exists() else 0
+        info(f"postgres: {db}.dump ({size:,} bytes)")
+
+
+def _extract_role_passwords(output: Path) -> None:
+    """Extract pw hashes from pg_authid (requires SUPERUSER)."""
+    sql = "SELECT rolname, rolpassword FROM pg_authid WHERE rolpassword IS NOT NULL;"
+    result = subprocess.run(
+        ["psql", "-U", "postgres", "-c", sql, "-t", "--no-align"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        warn(
+            f"postgres: could not read pg_authid (no SUPERUSER?): {result.stderr[:200]}"
+            " — role passwords will not be captured"
+        )
+        return
+
+    passwords: Dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        parts = line.strip().split("|")
+        if len(parts) == 2 and parts[0].strip() and parts[1].strip():
+            passwords[parts[0].strip()] = parts[1].strip()
+
+    if passwords:
+        output.write_text(json.dumps(passwords, indent=2), encoding="utf-8")
+        info(f"postgres: captured {len(passwords)} role password hash(es) → secrets staging")
+    else:
+        warn("postgres: no role passwords found in pg_authid")
+
+
+def _pg_version() -> str:
+    result = subprocess.run(
+        ["psql", "--version"], capture_output=True, text=True
+    )
+    return result.stdout.strip() if result.returncode == 0 else "unknown"

--- a/lib/phases/redis.py
+++ b/lib/phases/redis.py
@@ -1,0 +1,117 @@
+"""Capture phase: redis — SAVE, copy dump.rdb, record non-default CONFIG."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+from ..log import info, warn
+from . import Context, PhaseError
+
+_RDB_DEFAULT = Path("/var/lib/redis/dump.rdb")
+
+# Redis defaults we compare against when recording non-default CONFIG values.
+# Only keys that are commonly tuned and safe to record here.
+_CONFIG_DEFAULTS: Dict[str, str] = {
+    "maxmemory": "0",
+    "maxmemory-policy": "noeviction",
+    "save": "3600 1 300 100 60 10000",
+    "appendonly": "no",
+    "databases": "16",
+    "bind": "127.0.0.1 -::1",
+    "requirepass": "",
+    "loglevel": "notice",
+}
+
+
+def run(ctx: Context) -> None:
+    redis_dir = ctx.ensure_dir("data", "redis")
+
+    # SAVE (flush to disk)
+    info("redis: SAVE")
+    result = subprocess.run(
+        ["redis-cli", "SAVE"], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        warn(f"redis: SAVE failed: {result.stderr.strip()} — dump.rdb may be stale")
+
+    # Copy dump.rdb
+    if _RDB_DEFAULT.exists():
+        shutil.copy2(_RDB_DEFAULT, redis_dir / "dump.rdb")
+        size = _RDB_DEFAULT.stat().st_size
+        info(f"redis: copied dump.rdb ({size:,} bytes)")
+    else:
+        warn(f"redis: {_RDB_DEFAULT} not found — redis data not captured")
+
+    # CONFIG GET * → diff vs defaults
+    config_overrides = _get_config_overrides()
+    if config_overrides:
+        (redis_dir / "config.json").write_text(
+            json.dumps(config_overrides, indent=2), encoding="utf-8"
+        )
+        info(f"redis: recorded {len(config_overrides)} non-default CONFIG value(s)")
+    else:
+        info("redis: all CONFIG values are defaults (config.json skipped)")
+
+    # Count keys for manifest
+    key_count = _count_keys()
+    ctx.manifest.components["redis"] = {
+        "db_count": _count_dbs(),
+        "key_count": key_count,
+    }
+    info(f"redis: done ({key_count} key(s))")
+
+
+def _get_config_overrides() -> Dict[str, str]:
+    result = subprocess.run(
+        ["redis-cli", "CONFIG", "GET", "*"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        warn(f"redis: CONFIG GET failed: {result.stderr.strip()}")
+        return {}
+
+    # Output alternates key / value lines
+    lines = [l.strip() for l in result.stdout.splitlines() if l.strip()]
+    live: Dict[str, str] = {}
+    for i in range(0, len(lines) - 1, 2):
+        live[lines[i]] = lines[i + 1]
+
+    # Keep only keys that differ from defaults
+    overrides: Dict[str, str] = {}
+    for key, default in _CONFIG_DEFAULTS.items():
+        if key in live and live[key] != default:
+            overrides[key] = live[key]
+
+    return overrides
+
+
+def _count_keys() -> int:
+    try:
+        result = subprocess.run(
+            ["redis-cli", "INFO", "keyspace"],
+            capture_output=True, text=True, timeout=5,
+        )
+        total = 0
+        for line in result.stdout.splitlines():
+            if line.startswith("db"):
+                # e.g.: db0:keys=16540,expires=123,avg_ttl=0
+                parts = line.split("keys=")
+                if len(parts) == 2:
+                    total += int(parts[1].split(",")[0])
+        return total
+    except Exception:
+        return 0
+
+
+def _count_dbs() -> int:
+    try:
+        result = subprocess.run(
+            ["redis-cli", "INFO", "keyspace"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return sum(1 for line in result.stdout.splitlines() if line.startswith("db"))
+    except Exception:
+        return 0


### PR DESCRIPTION
## Description

Implements GH-21: the postgres and redis capture phases.

**lib/phases/postgres.py**
- Lists all user databases via `psql -lqt` (excludes template0, template1, postgres)
- `pg_dumpall --globals-only --no-role-passwords` → `data/postgres/globals.sql`
- `pg_dump --format=custom --compress=9` per database → `data/postgres/<db>.dump`
- Extracts role password hashes from `pg_authid` (requires SUPERUSER) → `ctx.secrets_staging/postgres/roles.json` for age-encryption by the secrets phase
- Warns (does not abort) if SUPERUSER access is unavailable
- Records `manifest.components.postgres = { version, databases: [...] }`

**lib/phases/redis.py**
- Runs `redis-cli SAVE` to flush the in-memory dataset to disk
- Copies `/var/lib/redis/dump.rdb` → `data/redis/dump.rdb`
- `CONFIG GET *` → diffs against a known set of defaults → saves non-default values to `data/redis/config.json`
- Records `manifest.components.redis = { db_count, key_count }`

All 23 existing unit tests pass.

Closes GH-21