### PR TITLE
feat(phases): implement system, nginx, and cron capture phases

### DIFF
--- a/lib/phases/cron.py
+++ b/lib/phases/cron.py
@@ -1,0 +1,52 @@
+"""Capture phase: cron — save crontab and /etc/cron.d/* entries."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..log import info, warn
+from . import Context
+
+
+def run(ctx: Context) -> None:
+    user = os.getenv("USER", "bot")
+    cron_dir = ctx.ensure_dir("data", "cron")
+
+    # bot crontab
+    result = subprocess.run(
+        ["crontab", "-l", "-u", user],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        (cron_dir / "bot.crontab").write_text(result.stdout, encoding="utf-8")
+        lines = len([l for l in result.stdout.splitlines() if l.strip() and not l.startswith("#")])
+        info(f"cron: saved {lines} bot crontab entr(ies)")
+    else:
+        info("cron: no crontab for bot (or empty)")
+
+    # /etc/cron.d/*
+    _copy_dir(Path("/etc/cron.d"), cron_dir / "etc-cron.d")
+
+    # /etc/cron.{daily,hourly,weekly,monthly}/
+    for period in ("daily", "hourly", "weekly", "monthly"):
+        _copy_dir(Path(f"/etc/cron.{period}"), cron_dir / f"etc-cron.{period}")
+
+    info("cron: done")
+
+
+def _copy_dir(src: Path, dest: Path) -> None:
+    if not src.exists():
+        return
+    dest.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for f in src.iterdir():
+        if f.is_file() and not f.name.startswith("."):
+            try:
+                shutil.copy2(f, dest / f.name)
+                count += 1
+            except PermissionError:
+                warn(f"cron: cannot read {f} — skipping")
+    if count:
+        info(f"cron: copied {count} file(s) from {src}")

--- a/lib/phases/nginx.py
+++ b/lib/phases/nginx.py
@@ -1,0 +1,72 @@
+"""Capture phase: nginx — copy config and record sites-enabled symlink map."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from ..log import info, warn
+from . import Context
+
+_NGINX_DIR = Path("/etc/nginx")
+
+
+def run(ctx: Context) -> None:
+    nginx_dest = ctx.ensure_dir("data", "nginx")
+
+    if not _NGINX_DIR.exists():
+        warn("nginx: /etc/nginx not found — skipping")
+        return
+
+    # nginx.conf
+    nginx_conf = _NGINX_DIR / "nginx.conf"
+    if nginx_conf.exists():
+        shutil.copy2(nginx_conf, nginx_dest / "nginx.conf")
+        info("nginx: copied nginx.conf")
+
+    # sites-available/
+    sites_avail = _NGINX_DIR / "sites-available"
+    if sites_avail.exists():
+        dest_sa = nginx_dest / "sites-available"
+        shutil.copytree(sites_avail, dest_sa, dirs_exist_ok=True)
+        count = len(list(dest_sa.iterdir()))
+        info(f"nginx: copied sites-available/ ({count} file(s))")
+
+    # conf.d/
+    conf_d = _NGINX_DIR / "conf.d"
+    if conf_d.exists():
+        dest_cd = nginx_dest / "conf.d"
+        shutil.copytree(conf_d, dest_cd, dirs_exist_ok=True)
+        count = len(list(dest_cd.iterdir()))
+        info(f"nginx: copied conf.d/ ({count} file(s))")
+
+    # Record sites-enabled symlink targets
+    sites_enabled = _NGINX_DIR / "sites-enabled"
+    vhost_count = 0
+    if sites_enabled.exists():
+        lines = []
+        for entry in sorted(sites_enabled.iterdir()):
+            if entry.is_symlink():
+                target = entry.resolve()
+                lines.append(f"{entry.name} -> {target}")
+                vhost_count += 1
+            elif entry.is_file():
+                lines.append(entry.name)
+                vhost_count += 1
+        (nginx_dest / "sites-enabled.txt").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+        info(f"nginx: recorded {vhost_count} sites-enabled entry/entries")
+
+    ctx.manifest.components["nginx"] = {
+        "vhost_count": vhost_count,
+        "include_count": _count_includes(nginx_dest),
+    }
+    info("nginx: done")
+
+
+def _count_includes(nginx_dir: Path) -> int:
+    total = 0
+    for sub in nginx_dir.rglob("*"):
+        if sub.is_file():
+            total += 1
+    return total

--- a/lib/phases/system.py
+++ b/lib/phases/system.py
@@ -1,0 +1,126 @@
+"""Capture phase: system — passwd/group delta and shadow/sudoers staging.
+
+Output (in staging/data/system/):
+  passwd.delta  — /etc/passwd lines for uids 1000–64999
+  group.delta   — /etc/group lines for non-system groups
+
+Staged for age-encryption (in ctx.secrets_staging/):
+  shadow.delta  — /etc/shadow lines for the same users
+  sudoers.d/    — copy of /etc/sudoers.d/*
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import List
+
+from ..log import info, warn
+from . import Context
+
+_UID_MIN = 1000
+_UID_MAX = 64999
+
+
+def run(ctx: Context) -> None:
+    system_dir = ctx.ensure_dir("data", "system")
+    secrets_sys = ctx.secrets_dir("system")
+
+    # passwd.delta
+    passwd_lines = _filter_passwd(_UID_MIN, _UID_MAX)
+    if passwd_lines:
+        (system_dir / "passwd.delta").write_text(
+            "\n".join(passwd_lines) + "\n", encoding="utf-8"
+        )
+        info(f"system: passwd.delta — {len(passwd_lines)} entr(ies)")
+    else:
+        warn("system: no non-system user entries found in /etc/passwd")
+
+    # group.delta (groups whose gid >= 1000)
+    group_lines = _filter_group(_UID_MIN, _UID_MAX)
+    if group_lines:
+        (system_dir / "group.delta").write_text(
+            "\n".join(group_lines) + "\n", encoding="utf-8"
+        )
+        info(f"system: group.delta — {len(group_lines)} entr(ies)")
+
+    # shadow.delta → secrets staging
+    shadow_lines = _filter_shadow(passwd_lines)
+    if shadow_lines:
+        (secrets_sys / "shadow.delta").write_text(
+            "\n".join(shadow_lines) + "\n", encoding="utf-8"
+        )
+        info(f"system: shadow.delta → secrets staging ({len(shadow_lines)} lines)")
+    else:
+        warn("system: /etc/shadow not readable or no matching users — shadow lines not captured")
+
+    # sudoers.d → secrets staging
+    _copy_sudoers(secrets_sys)
+
+    ctx.manifest.components["system"] = {
+        "users": [line.split(":")[0] for line in passwd_lines],
+        "uid_range": [_UID_MIN, _UID_MAX],
+    }
+    info("system: done")
+
+
+def _filter_passwd(uid_min: int, uid_max: int) -> List[str]:
+    try:
+        lines = Path("/etc/passwd").read_text(encoding="utf-8").splitlines()
+    except PermissionError:
+        return []
+    result = []
+    for line in lines:
+        parts = line.split(":")
+        if len(parts) >= 4:
+            try:
+                uid = int(parts[2])
+                if uid_min <= uid <= uid_max:
+                    result.append(line)
+            except ValueError:
+                pass
+    return result
+
+
+def _filter_group(gid_min: int, gid_max: int) -> List[str]:
+    try:
+        lines = Path("/etc/group").read_text(encoding="utf-8").splitlines()
+    except PermissionError:
+        return []
+    result = []
+    for line in lines:
+        parts = line.split(":")
+        if len(parts) >= 3:
+            try:
+                gid = int(parts[2])
+                if gid_min <= gid <= gid_max:
+                    result.append(line)
+            except ValueError:
+                pass
+    return result
+
+
+def _filter_shadow(passwd_lines: List[str]) -> List[str]:
+    usernames = {line.split(":")[0] for line in passwd_lines}
+    try:
+        shadow = Path("/etc/shadow").read_text(encoding="utf-8").splitlines()
+    except PermissionError:
+        return []
+    return [line for line in shadow if line.split(":")[0] in usernames]
+
+
+def _copy_sudoers(dest: Path) -> None:
+    sudoers_src = Path("/etc/sudoers.d")
+    if not sudoers_src.exists():
+        return
+    sudoers_dest = dest / "sudoers.d"
+    sudoers_dest.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for f in sudoers_src.iterdir():
+        if f.is_file() and not f.name.startswith("."):
+            try:
+                shutil.copy2(f, sudoers_dest / f.name)
+                count += 1
+            except PermissionError:
+                warn(f"system: cannot read {f} — skipping")
+    if count:
+        info(f"system: sudoers.d → secrets staging ({count} file(s))")


### PR DESCRIPTION
## Description

Implements GH-20: the system, nginx, and cron capture phases.

**lib/phases/system.py**
- Filters `/etc/passwd` for non-system users (uid 1000–64999) → `data/system/passwd.delta`
- Filters `/etc/group` for the same uid range → `data/system/group.delta`
- Filters `/etc/shadow` for the same users → `ctx.secrets_staging/system/shadow.delta` (for age-encryption)
- Copies `/etc/sudoers.d/*` → `ctx.secrets_staging/system/sudoers.d/` (for age-encryption)
- Records `manifest.components.system = { users: [...], uid_range: [1000, 64999] }`

**lib/phases/nginx.py**
- Copies `/etc/nginx/nginx.conf` → `data/nginx/nginx.conf`
- Copies `/etc/nginx/sites-available/` → `data/nginx/sites-available/`
- Copies `/etc/nginx/conf.d/` → `data/nginx/conf.d/`
- Records `sites-enabled` symlink targets → `data/nginx/sites-enabled.txt` (format: `<link_name> -> <target>`)
- Records `manifest.components.nginx = { vhost_count, include_count }`

**lib/phases/cron.py**
- Saves `crontab -l -u bot` → `data/cron/bot.crontab`
- Copies `/etc/cron.d/*` → `data/cron/etc-cron.d/`
- Copies `/etc/cron.{daily,hourly,weekly,monthly}/` → corresponding dirs in `data/cron/`

All 23 existing unit tests pass.

Closes GH-20