### PR TITLE
feat(phases): implement preflight + git-sync; wire capture pipeline

### DIFF
--- a/lib/commands/capture.py
+++ b/lib/commands/capture.py
@@ -1,15 +1,83 @@
-"""capture subcommand — stub. Phase modules wire in via subsequent PRs."""
+"""capture subcommand — full 14-phase capture pipeline.
+
+Phases (in order):
+  preflight, git-sync, inventory, packages, system, nginx, cron,
+  postgres, redis, pm2, state, secrets, checksums, package
+"""
 from __future__ import annotations
 
+import importlib
+import tempfile
+from pathlib import Path
 from typing import List
 
-from ..log import info
+from ..cli import EXIT_OK, EXIT_USER_ERROR, EXIT_GIT_SYNC_CONFLICT
+from ..log import error, info, warn
+from ..manifest import Manifest
+from ..phases import Context, PhaseError
+
+_PHASE_MODULE_MAP = {
+    "preflight":  "preflight",
+    "git-sync":   "git_sync",
+    "inventory":  "inventory",
+    "packages":   "packages",
+    "system":     "system",
+    "nginx":      "nginx",
+    "cron":       "cron",
+    "postgres":   "postgres",
+    "redis":      "redis",
+    "pm2":        "pm2",
+    "state":      "state",
+    "secrets":    "secrets",
+    "checksums":  "checksums",
+    "package":    "package",
+}
 
 
 def run(args, phases: List[str]) -> int:
-    info(f"capture plan: phases={phases} out={args.out or '<auto>'} dry_run={args.dry_run}")
+    info(f"capture: phases={', '.join(phases)} out={args.out or '<auto>'} dry_run={args.dry_run}")
+
     if args.dry_run:
-        info("dry-run mode — no actions taken")
-        return 0
-    info("capture pipeline not yet implemented (foundations PR only)")
-    return 0
+        info(f"capture: dry-run — phases that would run: {', '.join(phases)}")
+        return EXIT_OK
+
+    staging = Path(tempfile.mkdtemp(prefix="gb-capture-"))
+    secrets_staging = Path(tempfile.mkdtemp(prefix="gb-secrets-"))
+    try:
+        return _run_pipeline(args, phases, staging, secrets_staging)
+    finally:
+        import shutil
+        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(secrets_staging, ignore_errors=True)
+
+
+def _run_pipeline(
+    args, phases: List[str], staging: Path, secrets_staging: Path
+) -> int:
+    manifest = Manifest()
+    ctx = Context(
+        args=args,
+        staging=staging,
+        secrets_staging=secrets_staging,
+        manifest=manifest,
+    )
+
+    for phase in phases:
+        module_name = _PHASE_MODULE_MAP.get(phase)
+        if not module_name:
+            warn(f"capture: no implementation for phase {phase!r} — skipping")
+            continue
+
+        info(f"capture: [{phase}] starting")
+        try:
+            mod = importlib.import_module(f"..phases.{module_name}", package=__name__)
+            mod.run(ctx)
+            info(f"capture: [{phase}] done")
+        except PhaseError as exc:
+            error(f"capture: [{phase}] FAILED: {exc}")
+            return exc.exit_code
+        except Exception as exc:
+            error(f"capture: [{phase}] unexpected error: {exc}")
+            return 1
+
+    return EXIT_OK

--- a/lib/phases/__init__.py
+++ b/lib/phases/__init__.py
@@ -1,0 +1,91 @@
+"""Capture- and restore-side phases.
+
+Each phase is a small module exposing a single ``run(ctx)`` function that
+takes a :class:`Context` and either succeeds or raises a
+:class:`PhaseError`. Phases are independently re-runnable; the orchestrator
+in ``commands/capture.py`` and ``commands/restore.py`` decides which to
+invoke and in what order.
+"""
+from __future__ import annotations
+
+import dataclasses as dc
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..manifest import Manifest
+
+
+class PhaseError(Exception):
+    """Raised by a phase to signal a non-recoverable failure.
+
+    ``exit_code`` lets a phase request a specific top-level exit code
+    (e.g., 5 for git-sync conflicts).
+    """
+
+    def __init__(self, message: str, exit_code: int = 1) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+@dc.dataclass
+class Context:
+    """Shared state passed between capture phases.
+
+    ``staging`` is the working directory where every phase drops its
+    artifacts. ``secrets_staging`` is a separate dir holding plaintext
+    files that must be encrypted before reaching the bundle.
+    """
+
+    args: Any
+    staging: Path
+    secrets_staging: Path
+    manifest: Manifest
+    projects_json: Optional[Dict[str, Any]] = None
+    # Phases may stash arbitrary intermediates here.
+    extras: Dict[str, Any] = dc.field(default_factory=dict)
+
+    def ensure_dir(self, *parts: str) -> Path:
+        p = self.staging.joinpath(*parts)
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def secrets_dir(self, *parts: str) -> Path:
+        p = self.secrets_staging.joinpath(*parts)
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+
+def load_projects_json(path: os.PathLike) -> Dict[str, Any]:
+    """Read ~/.orchestrator/config/projects.json. Missing → empty registry.
+
+    Returned dict matches the on-disk shape: ``{"projects": {<name>: {...}}}``
+    so callers can branch cleanly on absence.
+    """
+    p = Path(path)
+    if not p.exists():
+        return {"projects": {}}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def project_entries(projects_json: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Flatten the registry into a sorted list of project entries with a
+    `name` key, dropping any that lack a `github_repo` (per PRD §5)."""
+    out: List[Dict[str, Any]] = []
+    raw = projects_json.get("projects") or {}
+    for name, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        if not entry.get("github_repo"):
+            continue
+        merged = {"name": name, **entry}
+        out.append(merged)
+    out.sort(key=lambda e: e["name"])
+    return out
+
+
+def disk_free_bytes(path: os.PathLike) -> int:
+    """Bytes free on the filesystem holding ``path``."""
+    return shutil.disk_usage(Path(path)).free

--- a/lib/phases/git_sync.py
+++ b/lib/phases/git_sync.py
@@ -1,0 +1,135 @@
+"""Capture phase: git-sync — push all registered projects to their remotes.
+
+For each project in ~/.orchestrator/config/projects.json with a github_repo:
+  1. git -C <dir> fetch origin
+  2. If clean: ensure all commits pushed (git push origin <branch>)
+  3. If dirty + --allow-snapshot-commit (default): git add -A && git commit -m "snapshot: ..."
+                                                   then push
+  4. If dirty + --no-snapshot-commit: add to error list; abort if non-empty
+
+On success, records {name, git_url, branch, sha, project_dir, deploy_type,
+env_paths, pm2_apps, db_names} into manifest.projects[].
+
+Exit code 5 is returned via PhaseError if dirty repos exist and snapshot
+commits are disabled.
+"""
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+from ..log import info, warn
+from ..manifest import Project
+from . import Context, PhaseError, project_entries
+
+
+def run(ctx: Context) -> None:
+    projects = project_entries(ctx.projects_json or {})
+    if not projects:
+        info("git-sync: no projects to sync")
+        return
+
+    allow_snapshot = getattr(ctx.args, "allow_snapshot_commit", True)
+    dirty_errors: List[str] = []
+    synced: List[Project] = []
+
+    for proj in projects:
+        name = proj["name"]
+        proj_dir = Path(proj.get("project_dir", ""))
+        github_repo = proj.get("github_repo", "")
+
+        if not proj_dir.exists():
+            warn(f"git-sync: [{name}] project_dir not found: {proj_dir} — skipping")
+            continue
+        if not (proj_dir / ".git").exists():
+            warn(f"git-sync: [{name}] not a git repo — skipping")
+            continue
+
+        info(f"git-sync: [{name}] syncing")
+
+        # Fetch
+        _git(proj_dir, ["fetch", "--quiet", "origin"])
+
+        # Check if dirty
+        dirty_files = _dirty_files(proj_dir)
+        if dirty_files:
+            if allow_snapshot:
+                _snapshot_commit(proj_dir, name)
+            else:
+                dirty_errors.append(
+                    f"{name}: {len(dirty_files)} uncommitted file(s) — use "
+                    "--allow-snapshot-commit to auto-commit"
+                )
+                continue
+
+        # Push
+        branch = _current_branch(proj_dir)
+        result = subprocess.run(
+            ["git", "-C", str(proj_dir), "push", "origin", branch],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            warn(f"git-sync: [{name}] push failed: {result.stderr[:200]}")
+
+        sha = _current_sha(proj_dir)
+        info(f"git-sync: [{name}] @ {sha[:8]} on {branch}")
+
+        synced.append(Project(
+            name=name,
+            git_url=github_repo,
+            branch=branch,
+            sha=sha,
+            project_dir=str(proj_dir),
+            deploy_type=proj.get("deploy_type", ""),
+            env_paths=list(proj.get("env_paths", [])),
+            pm2_apps=list(proj.get("pm2_apps", [])),
+            db_names=list(proj.get("db_names", [])),
+        ))
+
+    ctx.manifest.projects = synced
+    info(f"git-sync: synced {len(synced)}/{len(projects)} project(s)")
+
+    if dirty_errors:
+        raise PhaseError(
+            f"{len(dirty_errors)} project(s) have uncommitted changes:\n"
+            + "\n".join(f"  • {e}" for e in dirty_errors),
+            exit_code=5,
+        )
+
+
+def _git(proj_dir: Path, args: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(proj_dir)] + args,
+        capture_output=True, text=True,
+    )
+
+
+def _dirty_files(proj_dir: Path) -> List[str]:
+    result = _git(proj_dir, ["status", "--porcelain"])
+    return [l for l in result.stdout.splitlines() if l.strip()]
+
+
+def _snapshot_commit(proj_dir: Path, name: str) -> None:
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _git(proj_dir, ["add", "-A"])
+    result = _git(proj_dir, [
+        "commit",
+        "-m", f"snapshot: pre-backup capture {stamp}",
+        "--no-verify",
+    ])
+    if result.returncode != 0:
+        warn(f"git-sync: [{name}] snapshot commit failed: {result.stderr[:200]}")
+    else:
+        info(f"git-sync: [{name}] snapshot commit created")
+
+
+def _current_branch(proj_dir: Path) -> str:
+    result = _git(proj_dir, ["rev-parse", "--abbrev-ref", "HEAD"])
+    return result.stdout.strip() or "main"
+
+
+def _current_sha(proj_dir: Path) -> str:
+    result = _git(proj_dir, ["rev-parse", "HEAD"])
+    return result.stdout.strip()

--- a/lib/phases/preflight.py
+++ b/lib/phases/preflight.py
@@ -1,0 +1,59 @@
+"""Capture phase: preflight — validate required tools, disk space, projects.json.
+
+Fails fast if:
+  - Any required tool is missing
+  - Staging directory has insufficient free space (< 2 GB)
+  - projects.json cannot be loaded (missing is ok; no projects captured)
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from ..log import info, warn
+from . import Context, PhaseError, disk_free_bytes, load_projects_json
+
+_REQUIRED_TOOLS = ["git", "pg_dump", "redis-cli", "tar", "zstd", "age"]
+_STAGING_MIN_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB
+_PROJECTS_JSON_PATH = Path.home() / ".orchestrator" / "config" / "projects.json"
+
+
+def run(ctx: Context) -> None:
+    errors: list[str] = []
+
+    # Check required tools
+    missing = [t for t in _REQUIRED_TOOLS if not shutil.which(t)]
+    if missing:
+        errors.append(f"Missing tools: {', '.join(missing)}")
+    else:
+        info(f"preflight: all required tools present ({', '.join(_REQUIRED_TOOLS)})")
+
+    # Check staging disk space
+    free = disk_free_bytes(ctx.staging.parent)
+    if free < _STAGING_MIN_BYTES:
+        errors.append(
+            f"Insufficient disk space: {free // (1024 ** 3)} GB free "
+            f"(need {_STAGING_MIN_BYTES // (1024 ** 3)} GB)"
+        )
+    else:
+        info(f"preflight: disk space ok ({free // (1024 ** 3)} GB free)")
+
+    # Load projects.json
+    projects_json_path = _PROJECTS_JSON_PATH
+    projects_json = load_projects_json(projects_json_path)
+    project_count = len(projects_json.get("projects", {}))
+    ctx.projects_json = projects_json
+
+    if project_count == 0:
+        warn(
+            f"preflight: no projects found in {projects_json_path} "
+            "(git-sync phase will be a no-op)"
+        )
+    else:
+        info(f"preflight: found {project_count} project(s) in projects.json")
+
+    if errors:
+        raise PhaseError("preflight failed:\n" + "\n".join(f"  • {e}" for e in errors))
+
+    info("preflight: all checks passed")

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -1,0 +1,176 @@
+"""Unit tests for git-sync phase — projects.json parsing and manifest.projects[] population."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lib.phases import Context, PhaseError, load_projects_json, project_entries
+from lib.manifest import Manifest
+
+
+class LoadProjectsJsonTests(unittest.TestCase):
+    def test_missing_file_returns_empty(self) -> None:
+        result = load_projects_json("/nonexistent/path/projects.json")
+        self.assertEqual(result, {"projects": {}})
+
+    def test_loads_valid_json(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"projects": {"foo": {"github_repo": "https://github.com/x/foo"}}}, f)
+            path = f.name
+        try:
+            result = load_projects_json(path)
+            self.assertIn("projects", result)
+            self.assertIn("foo", result["projects"])
+        finally:
+            os.unlink(path)
+
+    def test_returns_empty_on_missing_github_repo(self) -> None:
+        raw = {"projects": {"no-remote": {"name": "no-remote"}}}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(raw, f)
+            path = f.name
+        try:
+            entries = project_entries(load_projects_json(path))
+            self.assertEqual(entries, [])
+        finally:
+            os.unlink(path)
+
+
+class ProjectEntriesTests(unittest.TestCase):
+    def _make_projects_json(self, projects: dict) -> dict:
+        return {"projects": projects}
+
+    def test_returns_sorted_by_name(self) -> None:
+        raw = self._make_projects_json({
+            "zebra": {"github_repo": "https://github.com/x/zebra"},
+            "alpha": {"github_repo": "https://github.com/x/alpha"},
+        })
+        entries = project_entries(raw)
+        self.assertEqual([e["name"] for e in entries], ["alpha", "zebra"])
+
+    def test_injects_name_key(self) -> None:
+        raw = self._make_projects_json({
+            "my-proj": {"github_repo": "https://github.com/x/my-proj", "deploy_type": "nginx"}
+        })
+        entries = project_entries(raw)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "my-proj")
+        self.assertEqual(entries[0]["deploy_type"], "nginx")
+
+    def test_skips_non_dict_entries(self) -> None:
+        raw = self._make_projects_json({"bad": "not-a-dict"})
+        entries = project_entries(raw)
+        self.assertEqual(entries, [])
+
+    def test_empty_projects_dict(self) -> None:
+        self.assertEqual(project_entries({"projects": {}}), [])
+        self.assertEqual(project_entries({}), [])
+
+
+class GitSyncManifestPopulationTests(unittest.TestCase):
+    """Integration-style tests using a real bare-repo + working clone."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp()
+        self._bare = Path(self._tmp) / "origin.git"
+        self._work = Path(self._tmp) / "work"
+
+        subprocess.run(["git", "init", "--bare", str(self._bare)], check=True, capture_output=True)
+        subprocess.run(["git", "clone", str(self._bare), str(self._work)], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(self._work), "config", "user.email", "t@test.com"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(self._work), "config", "user.name", "Test"], check=True, capture_output=True)
+
+        # Initial commit
+        (self._work / "README.md").write_text("hello")
+        subprocess.run(["git", "-C", str(self._work), "add", "README.md"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(self._work), "commit", "-m", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(self._work), "push", "origin", "HEAD"], check=True, capture_output=True)
+        self._initial_sha = subprocess.check_output(
+            ["git", "-C", str(self._work), "rev-parse", "HEAD"],
+            text=True
+        ).strip()
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _make_ctx(self, allow_snapshot: bool = True) -> Context:
+        staging = Path(tempfile.mkdtemp(prefix="gb-test-staging-"))
+        secrets = Path(tempfile.mkdtemp(prefix="gb-test-secrets-"))
+
+        class FakeArgs:
+            allow_snapshot_commit = allow_snapshot
+            include_logs = False
+            dry_run = False
+            out = None
+            age_recipient = None
+
+        projects_json = {
+            "projects": {
+                "test-proj": {
+                    "github_repo": f"file://{self._bare}",
+                    "project_dir": str(self._work),
+                    "deploy_type": "nginx",
+                    "pm2_apps": ["my-api"],
+                    "db_names": ["my_db"],
+                }
+            }
+        }
+        manifest = Manifest()
+        ctx = Context(
+            args=FakeArgs(),
+            staging=staging,
+            secrets_staging=secrets,
+            manifest=manifest,
+            projects_json=projects_json,
+        )
+        return ctx
+
+    def test_clean_repo_populates_manifest(self) -> None:
+        from lib.phases.git_sync import run
+        ctx = self._make_ctx()
+        run(ctx)
+
+        self.assertEqual(len(ctx.manifest.projects), 1)
+        proj = ctx.manifest.projects[0]
+        self.assertEqual(proj.name, "test-proj")
+        self.assertEqual(proj.sha, self._initial_sha)
+        self.assertEqual(proj.deploy_type, "nginx")
+        self.assertEqual(proj.pm2_apps, ["my-api"])
+        self.assertEqual(proj.db_names, ["my_db"])
+
+    def test_dirty_no_snapshot_raises_exit5(self) -> None:
+        from lib.phases.git_sync import run
+        (self._work / "README.md").write_text("modified")
+        ctx = self._make_ctx(allow_snapshot=False)
+        with self.assertRaises(PhaseError) as cm:
+            run(ctx)
+        self.assertEqual(cm.exception.exit_code, 5)
+
+    def test_dirty_with_snapshot_creates_commit(self) -> None:
+        from lib.phases.git_sync import run
+        (self._work / "README.md").write_text("modified")
+        ctx = self._make_ctx(allow_snapshot=True)
+        run(ctx)
+
+        self.assertEqual(len(ctx.manifest.projects), 1)
+        new_sha = ctx.manifest.projects[0].sha
+        self.assertNotEqual(new_sha, self._initial_sha)
+
+        # Verify new SHA exists on origin
+        result = subprocess.run(
+            ["git", "-C", str(self._bare), "cat-file", "-t", new_sha],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(result.stdout.strip(), "commit")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Implements GH-18: the two foundational capture phases, the full capture pipeline orchestrator, and 10 unit tests.

**lib/phases/__init__.py** (committed for the first time)

This file provides the shared phase infrastructure that all 14 capture phase modules import from: `Context`, `PhaseError`, `load_projects_json`, `project_entries`, `disk_free_bytes`. It was written earlier but never committed — this PR adds it to the repo so the codebase is self-contained from a fresh clone.

**lib/phases/preflight.py**
- Checks all required tools are installed: `git`, `pg_dump`, `redis-cli`, `tar`, `zstd`, `age`
- Checks staging disk free space ≥ 2 GB
- Loads `~/.orchestrator/config/projects.json` into `ctx.projects_json`
- Raises `PhaseError` on any failure; missing tools and disk errors are bundled into one message

**lib/phases/git_sync.py**
- Iterates `ctx.projects_json` via `project_entries()` (sorted, github_repo required)
- Per project: `git fetch origin` → check dirty → snapshot commit if dirty + allowed → `git push`
- Records `{name, git_url, branch, sha, project_dir, deploy_type, env_paths, pm2_apps, db_names}` into `manifest.projects[]`
- If dirty + `--no-snapshot-commit`: raises `PhaseError(exit_code=5)` with list of dirty repos

**lib/commands/capture.py** (stub → real implementation)
- Creates two temp dirs: `staging/` (all phases write artifacts here) and `secrets_staging/` (for age-encrypted content)
- Instantiates `Manifest` and `Context`, then iterates the resolved phase list
- Imports each phase module dynamically; calls `mod.run(ctx)`
- Returns phase's `exit_code` on failure, EXIT_OK on success
- Cleans up both temp dirs on exit (success or failure)

**tests/test_git_sync.py** (10 new tests)
- `LoadProjectsJsonTests`: missing file → empty dict; valid JSON → parsed; no github_repo → filtered out
- `ProjectEntriesTests`: sorted by name; name key injected; non-dict entries skipped; empty input
- `GitSyncManifestPopulationTests` (integration tests with real git bare repo):
  - Clean repo → manifest.projects[] populated with correct sha, deploy_type, pm2_apps, db_names
  - Dirty repo + `--no-snapshot-commit` → PhaseError with exit_code=5
  - Dirty repo + default → snapshot commit created; new SHA in manifest; SHA exists on origin

Full test suite: **33 tests, all passing**.

Closes GH-18